### PR TITLE
Add pthread dependency to build

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -41,7 +41,8 @@ srcs = files('''
 '''.split())
 
 deps = [dependency('libfolly'),
-        dependency('jsoncpp')]
+        dependency('jsoncpp'),
+        dependency('threads')]
 oomd_lib = library('oomd',
                    srcs,
                    include_directories : inc,


### PR DESCRIPTION
oomd's async logging uses threads. Add thread dependency to fix
link time error.