### PR TITLE
Add install option to meson.build

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -42,11 +42,14 @@ deps = [dependency('jsoncpp'),
 oomd_lib = library('oomd',
                    srcs,
                    include_directories : inc,
+                   install: true,
                    dependencies : deps)
 executable('oomd_bin',
            files('Main.cpp'),
            include_directories : inc,
            dependencies : deps,
+           install: true,
+           install_rpath: join_paths(get_option('prefix'), get_option('libdir')),
            link_with : oomd_lib)
 
 gtest_dep = dependency('gtest', main : true, required : false)


### PR DESCRIPTION
When I package the oomd for archlinux, I found that ninja install didn't install anything.
I added install option to lib and executable, then I can install it