### PR TITLE
Update help text

### DIFF
--- a/Main.cpp
+++ b/Main.cpp
@@ -29,7 +29,7 @@ static constexpr auto kConfigFilePath = "/etc/oomd.json";
 
 static void printUsage() {
   std::cerr
-      << "usage: fb-oomd [-h] [--config CONFIG] [--dry] [--report] [--verbose]\n\n"
+      << "usage: oomd [-h] [--config CONFIG] [--dry] [--verbose]\n\n"
          "optional arguments:\n"
          "  -h, --help            show this help message and exit\n"
          "  --config CONFIG, -C CONFIG\n"


### PR DESCRIPTION
--report doesn't do anything anymore. `fb-oomd` should really be renamed
`oomd`.