### PR TITLE
Add inline logging option

### DIFF
--- a/Log.cpp
+++ b/Log.cpp
@@ -52,7 +52,11 @@ namespace Oomd {
 
 LogStream::~LogStream() {
   stream_ << '\n';
+#ifdef INLINE_LOGGING
+  std::cerr << "(inl) " << stream_.str();
+#else
   Log::get().debugLog(stream_.str());
+#endif
 }
 
 Log::Log(int kmsg_fd, std::ostream& debug_sink) : kmsg_fd_(kmsg_fd) {

--- a/Log.cpp
+++ b/Log.cpp
@@ -51,10 +51,10 @@ ssize_t writeFull(int fd, const char* msg_buf, size_t count) {
 namespace Oomd {
 
 LogStream::~LogStream() {
-  stream_ << '\n';
 #ifdef INLINE_LOGGING
-  std::cerr << "(inl) " << stream_.str();
+  std::cerr << "(inl) " << stream_.str() << std::endl;
 #else
+  stream_ << std::endl;
   Log::get().debugLog(stream_.str());
 #endif
 }

--- a/meson.build
+++ b/meson.build
@@ -63,55 +63,55 @@ gtest_dep = dependency('gtest', main : true, required : false)
 gmock_dep = dependency('gmock', required : false)
 if gtest_dep.found() and gmock_dep.found()
     deps += [gtest_dep, gmock_dep]
-    cpp_args += ['-DINLINE_LOGGING']
+    test_cpp_args += cpp_args + ['-DINLINE_LOGGING']
 
     config_tests = executable('oomd_config_tests',
                               'ConfigTest.cpp',
                               include_directories : inc,
-                              cpp_args : cpp_args,
+                              cpp_args : test_cpp_args,
                               dependencies : deps,
                               link_with : oomd_lib)
     detector_tests = executable('oomd_detector_tests',
                                 'OomDetectorTest.cpp',
                                 include_directories : inc,
-                                cpp_args : cpp_args,
+                                cpp_args : test_cpp_args,
                                 dependencies : deps,
                                 link_with : oomd_lib)
     killer_tests = executable('oomd_killer_tests',
                               'OomKillerTest.cpp',
                               include_directories : inc,
-                              cpp_args : cpp_args,
+                              cpp_args : test_cpp_args,
                               dependencies : deps,
                               link_with : oomd_lib)
     oomd_tests = executable('oomd_oomd_tests',
                             'OomdTest.cpp',
                             include_directories : inc,
-                            cpp_args : cpp_args,
+                            cpp_args : test_cpp_args,
                             dependencies : deps,
                             link_with : oomd_lib)
     context_tests = executable('oomd_context_tests',
                             files('shared/OomdContextTest.cpp'),
                             include_directories : inc,
-                            cpp_args : cpp_args,
+                            cpp_args : test_cpp_args,
                             dependencies : deps,
                             link_with : oomd_lib)
     util_tests = executable('oomd_util_tests',
                             'util/FsTest.cpp',
                             'util/ScopeGuardTest.cpp',
                             include_directories : inc,
-                            cpp_args : cpp_args,
+                            cpp_args : test_cpp_args,
                             dependencies : deps,
                             link_with : oomd_lib)
     log_tests = executable('oomd_log_tests',
                             'LogTest.cpp',
                             include_directories : inc,
-                            cpp_args : cpp_args,
+                            cpp_args : test_cpp_args,
                             dependencies : deps,
                             link_with : oomd_lib)
     assert_tests = executable('oomd_assert_tests',
                             'include/AssertTest.cpp',
                             include_directories : inc,
-                            cpp_args : cpp_args,
+                            cpp_args : test_cpp_args,
                             dependencies : deps,
                             link_with : oomd_lib)
     test('context_tests', context_tests)

--- a/meson.build
+++ b/meson.build
@@ -63,6 +63,8 @@ gtest_dep = dependency('gtest', main : true, required : false)
 gmock_dep = dependency('gmock', required : false)
 if gtest_dep.found() and gmock_dep.found()
     deps += [gtest_dep, gmock_dep]
+    cpp_args += ['-DINLINE_LOGGING']
+
     config_tests = executable('oomd_config_tests',
                               'ConfigTest.cpp',
                               include_directories : inc,

--- a/meson.build
+++ b/meson.build
@@ -63,7 +63,7 @@ gtest_dep = dependency('gtest', main : true, required : false)
 gmock_dep = dependency('gmock', required : false)
 if gtest_dep.found() and gmock_dep.found()
     deps += [gtest_dep, gmock_dep]
-    test_cpp_args += cpp_args + ['-DINLINE_LOGGING']
+    test_cpp_args = cpp_args + ['-DINLINE_LOGGING']
 
     config_tests = executable('oomd_config_tests',
                               'ConfigTest.cpp',


### PR DESCRIPTION
By default logs are asynchronously written to stderr. That is to say,
it's done off thread. This patch introduces a compile time build option
that forces logs to print inline. This is useful for unit tests, where
we do not want logs to be spewing output after the test has ended.

Note this patch is currently branched off of another PR. I'll rebase
once the first one lands to clean it up.