### PR TITLE
Reduce sleeps in core plugin tests

### DIFF
--- a/plugins/BaseKillPlugin.cpp
+++ b/plugins/BaseKillPlugin.cpp
@@ -26,7 +26,6 @@
 
 #include "oomd/Log.h"
 #include "oomd/util/Fs.h"
-#include "oomd/util/ScopeGuard.h"
 
 static auto constexpr kOomdKillXattr = "trusted.oomd_kill";
 

--- a/plugins/BaseKillPlugin.cpp
+++ b/plugins/BaseKillPlugin.cpp
@@ -59,9 +59,6 @@ bool BaseKillPlugin::tryToKillCgroup(
     if (nr_killed == last_nr_killed) {
       break;
     }
-    OOMD_SCOPE_EXIT {
-      last_nr_killed = nr_killed;
-    };
 
     // Give it a breather before killing again
     //
@@ -70,6 +67,8 @@ bool BaseKillPlugin::tryToKillCgroup(
     if (last_nr_killed) {
       std::this_thread::sleep_for(1s);
     }
+
+    last_nr_killed = nr_killed;
   }
 
   reportToXattr(cgroup_path, nr_killed);

--- a/plugins/CorePluginsTest.cpp
+++ b/plugins/CorePluginsTest.cpp
@@ -20,6 +20,7 @@
 
 #include <algorithm>
 #include <memory>
+#include <unordered_set>
 
 #include "oomd/OomdContext.h"
 #include "oomd/PluginRegistry.h"
@@ -43,16 +44,20 @@ namespace Oomd {
 class BaseKillPluginMock : public BaseKillPlugin {
  public:
   int tryToKillPids(const std::vector<int>& pids) override {
-    killed.reserve(killed.size() + pids.size());
+    int ret = 0;
+    killed.reserve(pids.size());
 
     for (int pid : pids) {
-      killed.emplace_back(pid);
+      if (killed.find(pid) == killed.end()) {
+        killed.emplace(pid);
+        ++ret;
+      }
     }
 
-    return pids.size();
+    return ret;
   }
 
-  std::vector<int> killed;
+  std::unordered_set<int> killed;
 };
 
 /*


### PR DESCRIPTION
There used to be a lot of sleeps in the unit test code path.
This was because:
* the mocked out tryToKillPids would always "kill N pids", causing
  tryToKillCgroup to retry a bunch of times
* tryToKillCgroup was sleeping after each retry. This was to give
  the system time to respond to the SIGKILLs

The first issue is fixed in this patch using a set of "already killed"
pids. The second issue can be elided by removing the sleep after the
first set of kills (which isn't really necessary anyways).