### PR TITLE
Add command line option to specify cgroup2 filesystem mount point

### DIFF
--- a/Oomd.cpp
+++ b/Oomd.cpp
@@ -33,8 +33,6 @@
 #include "oomd/include/Defines.h"
 #include "oomd/util/Fs.h"
 
-static constexpr auto kCgroupFsRoot = "/sys/fs/cgroup";
-
 namespace {
 /*
  * Helper function that resolves a set of wildcarded cgroup paths.
@@ -62,8 +60,11 @@ std::unordered_set<std::string> resolveCgroupPaths(
 
 namespace Oomd {
 
-Oomd::Oomd(std::unique_ptr<Engine::Engine> engine, int interval)
-    : interval_(interval), engine_(std::move(engine)) {}
+Oomd::Oomd(
+    std::unique_ptr<Engine::Engine> engine,
+    int interval,
+    const std::string& cgroup_fs)
+    : interval_(interval), cgroup_fs_(cgroup_fs), engine_(std::move(engine)) {}
 
 bool Oomd::updateContextCgroup(
     const std::string& relative_cgroup_path,
@@ -159,7 +160,7 @@ int Oomd::run() {
     try {
       const auto before = std::chrono::steady_clock::now();
 
-      updateContext(kCgroupFsRoot, engine_->getMonitoredResources(), ctx);
+      updateContext(cgroup_fs_, engine_->getMonitoredResources(), ctx);
 
       // Run all the plugins
       engine_->runOnce(ctx);

--- a/Oomd.h
+++ b/Oomd.h
@@ -31,7 +31,10 @@ namespace Oomd {
 
 class Oomd {
  public:
-  Oomd(std::unique_ptr<Engine::Engine> engine, int interval);
+  Oomd(
+      std::unique_ptr<Engine::Engine> engine,
+      int interval,
+      const std::string& cgroup_fs);
   virtual ~Oomd() = default;
 
   /*
@@ -57,6 +60,7 @@ class Oomd {
 
   // runtime settings
   std::chrono::seconds interval_{0};
+  std::string cgroup_fs_;
   const double average_size_decay_{
       4}; // TODO(dlxu): migrate to ring buffer for raw datapoints so plugins
           // can calculate weighted average themselves

--- a/OomdTest.cpp
+++ b/OomdTest.cpp
@@ -30,7 +30,7 @@ constexpr auto kCgroupDataDir = "oomd/fixtures/cgroup";
 class OomdTest : public ::testing::Test {
  public:
   OomdTest() {
-    oomd = std::make_unique<::Oomd::Oomd>(nullptr, 5);
+    oomd = std::make_unique<::Oomd::Oomd>(nullptr, 5, kCgroupDataDir);
   }
 
   std::string cgroup_path{kCgroupDataDir};


### PR DESCRIPTION
Plugins already had the capability to specify custom mount cgroup2 mount
points.  However, core oomd did not have the same ability. In practice,
no plugin could have supported any system with cgroup2 mounted anywhere
other than /sys/fs/cgroup. However, this was still useful for tests.

This patch makes the feature useful, especially on systems where cgroup2
is mounted in "hybrid" locations, such as /sys/fs/cgroup/unified. Note
that in the latter case, the "hybird" cgroup2 mount would probably not
have had any real priviledges, and thus oomd would probably still not
have worked.