### PR TITLE
Return cleanly on errors instead of aborting 

### DIFF
--- a/Log.cpp
+++ b/Log.cpp
@@ -80,17 +80,17 @@ Log::~Log() {
   }
 }
 
-void Log::init_or_die() {
+bool Log::init() {
   int kmsg_fd = ::open("/dev/kmsg", O_WRONLY);
   if (kmsg_fd < 0) {
-    const int errcode = errno; // prevent errno clobbering
     perror("open");
-    OLOG << "Unable to open outfile (default=/dev/kmsg), not logging";
-    throw std::system_error(errcode, std::generic_category());
+    std::cerr << "Unable to open outfile (default=/dev/kmsg), not logging\n";
+    return false;
   }
 
   bool inline_logging = std::getenv("INLINE_LOGGING") ? true : false;
   Log::get(kmsg_fd, std::cerr, inline_logging);
+  return true;
 }
 
 Log& Log::get(int kmsg_fd, std::ostream& debug_sink, bool inl) {

--- a/Log.h
+++ b/Log.h
@@ -47,7 +47,7 @@ class Log {
   Log(const Log& other) = delete;
   Log& operator=(const Log& other) = delete;
   ~Log();
-  static void init_or_die();
+  static bool init();
   static Log&
   get(int kmsg_fd = -1, std::ostream& debug_sink = std::cerr, bool inl = true);
   static std::unique_ptr<Log>

--- a/Main.cpp
+++ b/Main.cpp
@@ -137,7 +137,10 @@ int main(int argc, char** argv) {
   // kmsg logging (due to some weird setup code required to get unit testing
   // correct). Be careful not to make any oomd library calls before initing
   // logging.
-  Oomd::Log::init_or_die();
+  if (!Oomd::Log::init()) {
+    std::cerr << "Logging failed to initialize. Try running with sudo\n";
+    return 1;
+  }
 
   if (!system_reqs_met()) {
     std::cerr << "System requirements not met\n";

--- a/Main.cpp
+++ b/Main.cpp
@@ -149,12 +149,18 @@ int main(int argc, char** argv) {
 
   // Load config
   std::ifstream conf_file(flag_conf_file, std::ios::in);
-  OCHECK(conf_file.is_open());
+  if (!conf_file.is_open()) {
+    std::cerr << "Could not open confg_file=" << flag_conf_file << std::endl;
+    return EXIT_CANT_RECOVER;
+  }
   std::stringstream buf;
   buf << conf_file.rdbuf();
   Oomd::Config2::JsonConfigParser json_parser;
   auto ir = json_parser.parse(buf.str());
-  OCHECK(ir != nullptr);
+  if (!ir) {
+    std::cerr << "Could not parse conf_file=" << flag_conf_file << std::endl;
+    return EXIT_CANT_RECOVER;
+  }
   auto engine = Oomd::Config2::compile(*ir);
 
   Oomd::Oomd oomd(std::move(engine), interval);

--- a/include/Assert.h
+++ b/include/Assert.h
@@ -24,3 +24,5 @@ __OCHECK_FAIL(const char* expr, const char* file, int line, const char* func);
   (static_cast<bool>(expr) \
        ? void(0)           \
        : __OCHECK_FAIL(#expr, __FILE__, __LINE__, __PRETTY_FUNCTION__))
+
+#define OCHECK_EXCEPT(expr, exc) (static_cast<bool>(expr)) ? void(0) : throw exc

--- a/include/AssertTest.cpp
+++ b/include/AssertTest.cpp
@@ -18,6 +18,8 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <exception>
+
 #include "oomd/include/Assert.h"
 
 using namespace testing;
@@ -36,4 +38,11 @@ TEST(OomdAssertTest, Death) {
 
 TEST(OomdAssertTest, ExprDeath) {
   ASSERT_DEATH(OCHECK(true == false), "Assertion.*failed");
+}
+
+TEST(OomdAssertExceptionTest, Throws) {
+  ASSERT_NO_THROW(OCHECK_EXCEPT(true, std::runtime_error("x")));
+  ASSERT_THROW(
+      OCHECK_EXCEPT(false, std::runtime_error("x")), std::runtime_error);
+  ASSERT_THROW(OCHECK_EXCEPT(false, std::exception()), std::exception);
 }

--- a/meson.build
+++ b/meson.build
@@ -37,6 +37,7 @@ srcs = files('''
     engine/Ruleset.h
     include/Assert.cpp
     include/Assert.h
+    include/Defines.h
     include/Types.h
     plugins/BaseKillPlugin.cpp
     plugins/BaseKillPlugin.h

--- a/util/Fs.h
+++ b/util/Fs.h
@@ -17,6 +17,7 @@
 
 #pragma once
 
+#include <exception>
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
@@ -28,6 +29,13 @@ namespace Oomd {
 
 class Fs {
  public:
+  class bad_control_file : public std::runtime_error {
+   public:
+    explicit bad_control_file(const std::string& msg)
+        : std::runtime_error(msg) {}
+    explicit bad_control_file(const char* msg) : std::runtime_error(msg) {}
+  };
+
   static constexpr auto kControllersFile = "cgroup.controllers";
   static constexpr auto kSubtreeControlFile = "cgroup.subtree_control";
   static constexpr auto kProcsFile = "cgroup.procs";


### PR DESCRIPTION
Aborting is bad because it creates a core dump. In isolated cases, this
is not too bad. However, when thousands of hosts are crash looping, it
burns through a lot of disk. Instead, we should return cleanly and let
systemd handle failures.

There is also another important benefit of this patch: it forces the
async logging thread to shut down cleanly. With this, we can ensure
logs do not get stranded in the buffer at shutdown.