### PR TITLE
Add clang-format check to travis build steps

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ before_install:
 
 install:
   - $SH "apt update"
-  - $SH "apt install -y pkg-config libsystemd-dev libjsoncpp-dev googletest meson"
+  - $SH "apt install -y pkg-config libsystemd-dev libjsoncpp-dev googletest meson clang-format"
 
 notifications:
   irc:
@@ -28,3 +28,4 @@ notifications:
 
 script:
   - $SH ./build-from-github.sh
+  - $SH './clang-format.sh && if [ $(git diff HEAD | wc -l) == "0" ]; then exit 0; else exit 1; fi'


### PR DESCRIPTION
This'll help people to remember to run `./clang-format`.