### PR TITLE
Create CgroupPath class

### DIFF
--- a/Main.cpp
+++ b/Main.cpp
@@ -28,6 +28,7 @@
 #include "oomd/config/ConfigCompiler.h"
 #include "oomd/config/JsonConfigParser.h"
 #include "oomd/include/Assert.h"
+#include "oomd/include/CgroupPath.h"
 #include "oomd/include/Defines.h"
 #include "oomd/util/Fs.h"
 
@@ -41,7 +42,6 @@ static void printUsage() {
          "  --help, -h                 Show this help message and exit\n"
          "  --config, -C CONFIG        Config file (default: /etc/oomd.json)\n"
          "  --interval, -i INTERVAL    Event loop polling interval (default: 5)\n"
-         "  --cgroup-fs, -f FS         Cgroup2 filesystem mount point (default: /sys/fs/cgroup)\n"
          "  --check-config, -c CONFIG  Check config file (default: /etc/oomd.json)\n"
       << std::endl;
 }
@@ -84,7 +84,6 @@ static std::unique_ptr<Oomd::Engine::Engine> parseAndCompile(
 
 int main(int argc, char** argv) {
   std::string flag_conf_file = kConfigFilePath;
-  std::string cgroup_fs = kCgroupFsRoot;
   int interval = 5;
   bool should_check_config = false;
 
@@ -129,9 +128,6 @@ int main(int argc, char** argv) {
         break;
       case 'i':
         interval = std::stoi(optarg);
-        break;
-      case 'f':
-        cgroup_fs = std::string(optarg);
         break;
       case 0:
         if (long_options[option_index].flag != nullptr) {
@@ -196,6 +192,6 @@ int main(int argc, char** argv) {
     return EXIT_CANT_RECOVER;
   }
 
-  Oomd::Oomd oomd(std::move(engine), interval, cgroup_fs);
+  Oomd::Oomd oomd(std::move(engine), interval);
   return oomd.run();
 }

--- a/Oomd.cpp
+++ b/Oomd.cpp
@@ -42,21 +42,33 @@ namespace {
 /*
  * Helper function that resolves a set of wildcarded cgroup paths.
  *
- * @returns a set of resolved absolute paths
+ * @returns a set of resolved cgroup paths
  */
-std::unordered_set<std::string> resolveCgroupPaths(
-    const std::string& cgroup_root_dir,
-    const std::unordered_set<std::string>& parent_cgroups) {
-  std::unordered_set<std::string> ret;
+std::unordered_set<Oomd::CgroupPath> resolveCgroupPaths(
+    const std::unordered_set<Oomd::CgroupPath>& cgroups) {
+  std::unordered_set<Oomd::CgroupPath> ret;
 
-  for (const auto& parent_cgroup : parent_cgroups) {
-    std::string abs_unresolved_path = cgroup_root_dir + "/" + parent_cgroup;
+  for (const auto& cgroup : cgroups) {
     // TODO: see what the performance penalty of walking the FS
     // (in resolveWildcardPath) every time is. If it's a big penalty,
-    // we could search `abs_unresolved_path` for any fnmatch operators and
+    // we could search `absolutePath` for any fnmatch operators and
     // only resolve if we find symbols.
-    auto resolved_paths = Oomd::Fs::resolveWildcardPath(abs_unresolved_path);
-    ret.insert(resolved_paths.begin(), resolved_paths.end());
+    auto resolved_paths = Oomd::Fs::resolveWildcardPath(cgroup.absolutePath());
+
+    for (const auto& resolved_path : resolved_paths) {
+      size_t idx = 0;
+
+      // TODO: make Fs::resolveWildcardPath return a "cleaned" path
+      if (resolved_path.find("./", 0) != std::string::npos) {
+        idx += 2;
+      }
+      idx += cgroup.cgroupFs().size() + /* trailing slash */ +1;
+
+      if (idx < resolved_path.size()) {
+        std::string cgroup_relative = resolved_path.substr(idx);
+        ret.emplace(cgroup.cgroupFs(), std::move(cgroup_relative));
+      }
+    }
   }
 
   return ret;
@@ -65,16 +77,12 @@ std::unordered_set<std::string> resolveCgroupPaths(
 
 namespace Oomd {
 
-Oomd::Oomd(
-    std::unique_ptr<Engine::Engine> engine,
-    int interval,
-    const std::string& cgroup_fs)
-    : interval_(interval), cgroup_fs_(cgroup_fs), engine_(std::move(engine)) {}
+Oomd::Oomd(std::unique_ptr<Engine::Engine> engine, int interval)
+    : interval_(interval), engine_(std::move(engine)) {}
 
-bool Oomd::updateContextCgroup(
-    const std::string& relative_cgroup_path,
-    const std::string& absolute_cgroup_path,
-    OomdContext& ctx) {
+bool Oomd::updateContextCgroup(const CgroupPath& path, OomdContext& ctx) {
+  std::string absolute_cgroup_path = path.absolutePath();
+
   // Warn once if memory controller is not enabled on target cgroup
   auto controllers = Fs::readControllers(absolute_cgroup_path);
   if (!std::any_of(controllers.begin(), controllers.end(), [](std::string& s) {
@@ -110,28 +118,25 @@ bool Oomd::updateContextCgroup(
   }
 
   ctx.setCgroupContext(
-      relative_cgroup_path,
+      path,
       {pressures, io_pressure, current, {}, memlow, swap_current, anon_usage});
 
   return true;
 }
 
 void Oomd::updateContext(
-    const std::string& cgroup_root_dir,
-    const std::unordered_set<std::string>& cgroups,
+    const std::unordered_set<CgroupPath>& cgroups,
     OomdContext& ctx) {
   OomdContext new_ctx;
 
-  auto resolved = resolveCgroupPaths(cgroup_root_dir, cgroups);
+  auto resolved = resolveCgroupPaths(cgroups);
   for (const auto& resolved_cgroup : resolved) {
     // Only care about subtree cgroups, not the cgroup files
-    if (!Fs::isDir(resolved_cgroup)) {
+    if (!Fs::isDir(resolved_cgroup.absolutePath())) {
       continue;
     }
 
-    std::string relative_cgroup_path = resolved_cgroup;
-    Fs::removePrefix(relative_cgroup_path, cgroup_root_dir + "/");
-    updateContextCgroup(relative_cgroup_path, resolved_cgroup, new_ctx);
+    updateContextCgroup(resolved_cgroup, new_ctx);
   }
 
   // calculate running averages
@@ -242,7 +247,7 @@ int Oomd::run() {
         return ret;
       }
 
-      updateContext(cgroup_fs_, engine_->getMonitoredResources(), ctx);
+      updateContext(engine_->getMonitoredResources(), ctx);
 
       // Run all the plugins
       engine_->runOnce(ctx);

--- a/Oomd.h
+++ b/Oomd.h
@@ -26,37 +26,27 @@
 #include <vector>
 
 #include "oomd/engine/Engine.h"
+#include "oomd/include/CgroupPath.h"
 
 namespace Oomd {
 
 class Oomd {
  public:
-  Oomd(
-      std::unique_ptr<Engine::Engine> engine,
-      int interval,
-      const std::string& cgroup_fs);
+  Oomd(std::unique_ptr<Engine::Engine> engine, int interval);
   virtual ~Oomd() = default;
 
   /*
    * This method updates @param ctx with the status of all the cgroups
-   * in @param cgroups. @param cgroup_root_dir is the location the cgroup2
-   * filesystem is mounted.
-   *
-   * Every cgroup in @param cgroups will be treated relative to
-   * @param cgroup_root_dir.
+   * in @param cgroups.
    */
   void updateContext(
-      const std::string& cgroup_root_dir,
-      const std::unordered_set<std::string>& cgroups,
+      const std::unordered_set<CgroupPath>& cgroups,
       OomdContext& ctx);
 
   int run();
 
  private:
-  bool updateContextCgroup(
-      const std::string& relative_cgroup_path,
-      const std::string& absolute_cgroup_path,
-      OomdContext& ctx);
+  bool updateContextCgroup(const CgroupPath& path, OomdContext& ctx);
   int prepEventLoop(const std::chrono::seconds& interval);
   int processEventLoop();
 
@@ -65,7 +55,6 @@ class Oomd {
 
   // runtime settings
   std::chrono::seconds interval_{0};
-  std::string cgroup_fs_;
   const double average_size_decay_{
       4}; // TODO(dlxu): migrate to ring buffer for raw datapoints so plugins
           // can calculate weighted average themselves

--- a/OomdContext.h
+++ b/OomdContext.h
@@ -24,6 +24,7 @@
 #include <unordered_map>
 #include <vector>
 
+#include "oomd/include/CgroupPath.h"
 #include "oomd/include/Types.h"
 
 namespace Oomd {
@@ -43,30 +44,30 @@ class OomdContext {
   /**
    * @returns whether or not OomdContext holds a particular cgroup
    */
-  bool hasCgroupContext(const std::string& name) const;
+  bool hasCgroupContext(const CgroupPath& path) const;
 
   /**
-   * @returns all the stored cgroup names (eg "chef.service")
+   * @returns all the stored cgroup paths
    */
-  std::vector<std::string> cgroups() const;
+  std::vector<CgroupPath> cgroups() const;
 
   /*
    * @returns a CgroupContext reference associated with @param name
    * @throws std::invalid_argument for missing cgroup
    */
-  const CgroupContext& getCgroupContext(const std::string& name);
+  const CgroupContext& getCgroupContext(const CgroupPath& path);
 
   /**
    * Assigns a mapping of cgroup -> CgroupContext
    */
-  void setCgroupContext(const std::string& name, CgroupContext context);
+  void setCgroupContext(const CgroupPath& path, CgroupContext context);
 
   /**
    * Manipulates CgroupContexts into helpful other helpful datastructures
    *
    * @param getKey is a lambda that accesses the key you want to reverse sort by
    */
-  std::vector<std::pair<std::string, CgroupContext>> reverseSort(
+  std::vector<std::pair<CgroupPath, CgroupContext>> reverseSort(
       std::function<double(const CgroupContext& cgroup_ctx)> getKey = nullptr);
 
   /**
@@ -74,7 +75,7 @@ class OomdContext {
    * reverseSort(std::function<...>)
    */
   static void reverseSort(
-      std::vector<std::pair<std::string, CgroupContext>>& vec,
+      std::vector<std::pair<CgroupPath, CgroupContext>>& vec,
       std::function<double(const CgroupContext& cgroup_ctx)> getKey);
 
   /**
@@ -82,7 +83,7 @@ class OomdContext {
    */
   void dump();
   static void dumpOomdContext(
-      const std::vector<std::pair<std::string, CgroupContext>>& vec,
+      const std::vector<std::pair<CgroupPath, CgroupContext>>& vec,
       const bool skip_negligible = false);
 
   /**
@@ -93,7 +94,7 @@ class OomdContext {
   void setActionContext(ActionContext context);
 
  private:
-  std::unordered_map<std::string, CgroupContext> memory_state_;
+  std::unordered_map<CgroupPath, CgroupContext> memory_state_;
   ActionContext action_context_;
 };
 

--- a/config/ConfigCompilerTest.cpp
+++ b/config/ConfigCompilerTest.cpp
@@ -35,6 +35,7 @@ namespace {
 int count;
 } // namespace
 
+static constexpr auto kRandomCgroupFs = "/some/random/fs";
 static constexpr auto kRandomCgroupDependency = "/some/random/cgroup";
 
 namespace Oomd {
@@ -102,7 +103,7 @@ class RegistrationPlugin : public BasePlugin {
   int init(
       Engine::MonitoredResources& resources,
       const PluginArgs& /* unused */) override {
-    resources.emplace(kRandomCgroupDependency);
+    resources.emplace(kRandomCgroupFs, kRandomCgroupDependency);
     return 0;
   }
 
@@ -235,7 +236,8 @@ TEST_F(CompilerTest, MonitoredResources) {
   auto engine = compile();
   ASSERT_TRUE(engine);
   EXPECT_THAT(
-      engine->getMonitoredResources(), Contains(kRandomCgroupDependency));
+      engine->getMonitoredResources(),
+      Contains(CgroupPath(kRandomCgroupFs, kRandomCgroupDependency)));
 }
 
 TEST_F(CompilerTest, NoInitPlugin) {

--- a/engine/BasePlugin.h
+++ b/engine/BasePlugin.h
@@ -22,6 +22,7 @@
 #include <unordered_set>
 
 #include "oomd/OomdContext.h"
+#include "oomd/include/CgroupPath.h"
 #include "oomd/include/Types.h"
 
 namespace Oomd {
@@ -32,7 +33,7 @@ enum class PluginRet {
   STOP,
 };
 
-using MonitoredResources = std::unordered_set<std::string>;
+using MonitoredResources = std::unordered_set<CgroupPath>;
 using PluginArgs = std::unordered_map<std::string, std::string>;
 
 class BasePlugin {

--- a/include/CgroupPath.cpp
+++ b/include/CgroupPath.cpp
@@ -1,0 +1,143 @@
+/*
+ * Copyright (C) 2018-present, Facebook, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include "oomd/include/CgroupPath.h"
+
+#include <exception>
+
+#include "oomd/util/Fs.h"
+
+namespace Oomd {
+
+CgroupPath::CgroupPath(
+    const std::string& cgroup_fs,
+    const std::string& cgroup_path)
+    : cgroup_fs_(cgroup_fs) {
+  // Strip trailing '/'
+  if (cgroup_fs_.at(cgroup_fs_.size() - 1) == '/' && cgroup_fs.size() > 1) {
+    cgroup_fs_.pop_back();
+  }
+
+  cgroup_path_ = Fs::split(cgroup_path, '/');
+}
+
+CgroupPath::CgroupPath(const CgroupPath& other) {
+  copyFrom(other);
+}
+
+CgroupPath::CgroupPath(CgroupPath&& other) {
+  moveFrom(std::move(other));
+}
+
+CgroupPath& CgroupPath::operator=(const CgroupPath& other) {
+  copyFrom(other);
+  return *this;
+}
+
+CgroupPath& CgroupPath::operator=(CgroupPath&& other) {
+  moveFrom(std::move(other));
+  return *this;
+}
+
+std::string CgroupPath::absolutePath() const {
+  std::string relpath = relativePath();
+  if (!relpath.size()) {
+    return cgroup_fs_;
+  }
+
+  std::string ret;
+  ret.reserve(cgroup_fs_.size() + 1 + relpath.size());
+  ret += cgroup_fs_;
+  ret += '/';
+  ret += std::move(relpath);
+
+  return ret;
+}
+
+std::string CgroupPath::relativePath() const {
+  size_t s = 0;
+  for (size_t i = 0; i < cgroup_path_.size(); ++i) {
+    s += cgroup_path_.at(i).size();
+    if (i == cgroup_path_.size() - 1) {
+      break;
+    }
+    ++s; // for the path separator
+  }
+
+  std::string ret;
+  ret.reserve(s);
+
+  for (size_t i = 0; i < cgroup_path_.size(); ++i) {
+    ret += cgroup_path_.at(i);
+    if (i == cgroup_path_.size() - 1) {
+      break;
+    }
+    ret += '/';
+  }
+
+  return ret;
+}
+
+std::string CgroupPath::name() const {
+  if (!cgroup_path_.size()) {
+    return {};
+  }
+
+  return cgroup_path_.at(cgroup_path_.size() - 1);
+}
+
+std::string CgroupPath::cgroupFs() const {
+  return cgroup_fs_;
+}
+
+void CgroupPath::ascend() {
+  if (!isRoot()) {
+    cgroup_path_.pop_back();
+  }
+}
+
+void CgroupPath::descend(const std::string& path) {
+  auto pieces = Fs::split(path, '/');
+  cgroup_path_.reserve(cgroup_path_.size() + pieces.size());
+  for (auto& piece : pieces) {
+    cgroup_path_.emplace_back(std::move(piece));
+  }
+}
+
+bool CgroupPath::operator==(const CgroupPath& other) const {
+  return this->absolutePath() == other.absolutePath();
+}
+
+bool CgroupPath::operator!=(const CgroupPath& other) const {
+  return !operator==(other);
+}
+
+bool CgroupPath::isRoot() const {
+  return cgroup_path_.size() == 0;
+}
+
+void CgroupPath::copyFrom(const CgroupPath& other) {
+  this->cgroup_fs_ = other.cgroup_fs_;
+  this->cgroup_path_ = other.cgroup_path_;
+}
+
+void CgroupPath::moveFrom(CgroupPath&& other) {
+  this->cgroup_fs_ = std::move(other.cgroup_fs_);
+  this->cgroup_path_ = std::move(other.cgroup_path_);
+}
+
+} // namespace Oomd

--- a/include/CgroupPath.h
+++ b/include/CgroupPath.h
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2018-present, Facebook, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#pragma once
+
+#include <functional>
+#include <string>
+#include <vector>
+
+namespace Oomd {
+
+class CgroupPath {
+ public:
+  CgroupPath(const std::string& cgroup_fs, const std::string& cgroup_path);
+  ~CgroupPath() = default;
+  CgroupPath(const CgroupPath& other);
+  CgroupPath(CgroupPath&& other);
+  CgroupPath& operator=(const CgroupPath& other);
+  CgroupPath& operator=(CgroupPath&& other);
+
+  std::string absolutePath() const;
+  // cgroup path without the cgroup fs
+  std::string relativePath() const;
+  // leaf of the path
+  std::string name() const;
+  std::string cgroupFs() const;
+
+  /*
+   * Ascend or descend up the cgroup filesystem
+   */
+  void ascend();
+  void descend(const std::string& path);
+
+  bool operator==(const CgroupPath& other) const;
+  bool operator!=(const CgroupPath& other) const;
+  // Do we represent the root cgroup?
+  bool isRoot() const;
+
+ private:
+  void copyFrom(const CgroupPath& other);
+  void moveFrom(CgroupPath&& other);
+
+  std::string cgroup_fs_;
+  std::vector<std::string> cgroup_path_;
+};
+
+} // namespace Oomd
+
+namespace std {
+template <>
+struct hash<Oomd::CgroupPath> {
+  size_t operator()(const Oomd::CgroupPath& path) const {
+    return hash<std::string>()(path.absolutePath());
+  }
+};
+} // namespace std

--- a/include/CgroupPathTest.cpp
+++ b/include/CgroupPathTest.cpp
@@ -1,0 +1,104 @@
+/*
+ * Copyright (C) 2018-present, Facebook, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <unordered_map>
+
+#include "oomd/include/CgroupPath.h"
+
+using namespace testing;
+using namespace Oomd;
+
+TEST(CgroupPathTest, ConstructorsTest) {
+  CgroupPath path1("/sys/fs/cgroup", "myservice");
+  CgroupPath path2(path1);
+  EXPECT_EQ(path1.absolutePath(), path2.absolutePath());
+  path1 = path2;
+  EXPECT_EQ(path1.absolutePath(), path2.absolutePath());
+
+  CgroupPath path3("/sys/fs/cgroup", "myservice");
+  CgroupPath path4(std::move(path3));
+  EXPECT_EQ(path4.absolutePath(), "/sys/fs/cgroup/myservice");
+  CgroupPath path5 = std::move(path4);
+  EXPECT_EQ(path5.absolutePath(), "/sys/fs/cgroup/myservice");
+}
+
+TEST(CgroupPathTest, GettersTest) {
+  CgroupPath path("/sys/fs/cgroup", "system.slice/myservice.slice");
+  EXPECT_EQ(path.absolutePath(), "/sys/fs/cgroup/system.slice/myservice.slice");
+  EXPECT_EQ(path.relativePath(), "system.slice/myservice.slice");
+  EXPECT_EQ(path.name(), "myservice.slice");
+  EXPECT_EQ(path.cgroupFs(), "/sys/fs/cgroup");
+
+  CgroupPath pathEmpty("/sys/fs/cgroup", "");
+  EXPECT_EQ(pathEmpty.name().size(), 0);
+  EXPECT_EQ(pathEmpty.relativePath().size(), 0);
+  EXPECT_EQ(pathEmpty.absolutePath(), "/sys/fs/cgroup");
+
+  CgroupPath pathSame("/sys/fs/cgroup", "////////");
+  EXPECT_EQ(pathSame.relativePath().size(), 0);
+  EXPECT_EQ(pathSame.absolutePath(), "/sys/fs/cgroup");
+}
+
+TEST(CgroupPathTest, ModifiersTest) {
+  CgroupPath path("/sys/fs/cgroup", "system.slice");
+  path.descend("myservice");
+  path.descend("/one/");
+  path.descend("two/");
+  path.descend("three");
+  EXPECT_EQ(path.relativePath(), "system.slice/myservice/one/two/three");
+
+  path.ascend();
+  path.ascend();
+  EXPECT_EQ(path.relativePath(), "system.slice/myservice/one");
+
+  for (int i = 0; i < 500; ++i) {
+    path.ascend();
+  }
+  EXPECT_EQ(path.relativePath().size(), 0);
+  EXPECT_EQ(path.absolutePath(), "/sys/fs/cgroup");
+}
+
+TEST(CgroupPathTest, ComparisonsTest) {
+  CgroupPath path1("/sys/fs/cgroup", "system.slice");
+  CgroupPath path2("/sys/fs/cgroup", "system.slice");
+  EXPECT_EQ(path1, path2);
+
+  CgroupPath path3("/sys/fs/cgroup", "asdf.slice");
+  EXPECT_NE(path1, path3);
+
+  EXPECT_FALSE(path3.isRoot());
+  path3.ascend();
+  EXPECT_TRUE(path3.isRoot());
+}
+
+TEST(CgroupPathTest, HashTest) {
+  std::unordered_map<CgroupPath, int> m;
+
+  CgroupPath p1("/sys/fs/cgroup", "system.slice");
+  CgroupPath p2("/sys/fs/cgroup", "workload.slice");
+  m[p1] = 1;
+  m[p2] = 2;
+
+  EXPECT_EQ(m[p1], 1);
+  EXPECT_EQ(m[p2], 2);
+
+  CgroupPath p3("/sys/fs/cgroup", "system.slice");
+  EXPECT_EQ(m[p3], 1);
+}

--- a/meson.build
+++ b/meson.build
@@ -27,6 +27,7 @@ srcs = files('''
     engine/Engine.cpp
     engine/Ruleset.cpp
     include/Assert.cpp
+    include/CgroupPath.cpp
     plugins/BaseKillPlugin.cpp
     plugins/ContinuePlugin.cpp
     plugins/DumpCgroupOverview.cpp
@@ -81,6 +82,7 @@ core_tests = [
   ['context',  files('OomdContextTest.cpp')],
   ['log',      files('LogTest.cpp')],
   ['assert',   files('include/AssertTest.cpp')],
+  ['cpath',    files('include/CgroupPathTest.cpp')],
   ['compiler', files('config/ConfigCompilerTest.cpp')],
   ['plugin',   files('plugins/CorePluginsTest.cpp')],
 ]

--- a/plugins/BaseKillPlugin.h
+++ b/plugins/BaseKillPlugin.h
@@ -61,7 +61,7 @@ class BaseKillPlugin : public Oomd::Engine::BasePlugin {
    * Logs a structured kill message to kmsg and stderr
    */
   virtual void logKill(
-      const std::string& killed_group,
+      const CgroupPath& killed_group,
       const CgroupContext& context,
       const ActionContext& action_context,
       bool dry = false) const;
@@ -74,8 +74,8 @@ class BaseKillPlugin : public Oomd::Engine::BasePlugin {
    * was not assigned to kill.
    */
   virtual void removeSiblingCgroups(
-      const std::unordered_set<std::string>& ours,
-      std::vector<std::pair<std::string, Oomd::CgroupContext>>& vec);
+      const std::unordered_set<CgroupPath>& ours,
+      std::vector<std::pair<CgroupPath, Oomd::CgroupContext>>& vec);
 
  private:
   virtual int getAndTryToKillPids(

--- a/plugins/KillMemoryGrowth.h
+++ b/plugins/KillMemoryGrowth.h
@@ -43,7 +43,7 @@ class KillMemoryGrowth : public Base {
   virtual bool tryToKillBySize(OomdContext& ctx, bool ignore_threshold);
   virtual bool tryToKillByGrowth(OomdContext& ctx);
 
-  std::unordered_set<std::string> cgroups_;
+  std::unordered_set<CgroupPath> cgroups_;
   std::string cgroup_fs_;
   int size_threshold_{50};
   int growing_size_percentile_{80};

--- a/plugins/KillPressure.h
+++ b/plugins/KillPressure.h
@@ -42,7 +42,7 @@ class KillPressure : public Base {
  protected:
   virtual bool tryToKillSomething(OomdContext& ctx);
 
-  std::unordered_set<std::string> cgroups_;
+  std::unordered_set<CgroupPath> cgroups_;
   std::string cgroup_fs_;
   ResourceType resource_;
   int post_action_delay_{15};

--- a/plugins/KillSwapUsage-inl.h
+++ b/plugins/KillSwapUsage-inl.h
@@ -33,12 +33,15 @@ int KillSwapUsage<Base>::init(
     Engine::MonitoredResources& resources,
     const Engine::PluginArgs& args) {
   if (args.find("cgroup") != args.end()) {
-    auto cgroups = Fs::split(args.at("cgroup"), ',');
-    resources.insert(cgroups.begin(), cgroups.end());
-    cgroups_.insert(cgroups.begin(), cgroups.end());
     cgroup_fs_ =
         (args.find("cgroup_fs") != args.end() ? args.at("cgroup_fs")
                                               : kCgroupFs);
+
+    auto cgroups = Fs::split(args.at("cgroup"), ',');
+    for (const auto& c : cgroups) {
+      resources.emplace(cgroup_fs_, c);
+      cgroups_.emplace(cgroup_fs_, c);
+    }
   } else {
     OLOG << "Argument=cgroup not present";
     return 1;
@@ -104,12 +107,11 @@ bool KillSwapUsage<Base>::tryToKillSomething(OomdContext& ctx) {
       continue;
     }
 
-    OLOG << "Picked \"" << state_pair.first << "\" ("
+    OLOG << "Picked \"" << state_pair.first.relativePath() << "\" ("
          << state_pair.second.current_usage / 1024 / 1024
          << "MB) based on swap usage at "
          << state_pair.second.swap_usage / 1024 / 1024 << "MB";
-    if (Base::tryToKillCgroup(
-            cgroup_fs_ + "/" + state_pair.first, true, dry_)) {
+    if (Base::tryToKillCgroup(state_pair.first.absolutePath(), true, dry_)) {
       Base::logKill(
           state_pair.first, state_pair.second, ctx.getActionContext(), dry_);
       return true;

--- a/plugins/KillSwapUsage.h
+++ b/plugins/KillSwapUsage.h
@@ -41,7 +41,7 @@ class KillSwapUsage : public Base {
  protected:
   virtual bool tryToKillSomething(OomdContext& ctx);
 
-  std::unordered_set<std::string> cgroups_;
+  std::unordered_set<CgroupPath> cgroups_;
   std::string cgroup_fs_;
   int post_action_delay_{15};
   bool dry_{false};

--- a/plugins/MemoryAbove.h
+++ b/plugins/MemoryAbove.h
@@ -39,7 +39,7 @@ class MemoryAbove : public Oomd::Engine::BasePlugin {
   ~MemoryAbove() = default;
 
  private:
-  std::unordered_set<std::string> cgroups_;
+  std::unordered_set<CgroupPath> cgroups_;
   std::string cgroup_fs_;
   // Initialized to bogus values; init() will crash oomd if non-0 return
   int threshold_;


### PR DESCRIPTION
This class will abstract the path of a cgroup. Previously, we were using
strings of paths. This was messy and error prone. This class
standardizes the representation and should prevent mistakes.