### PR TITLE
[oomd] Bump compiler version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ before_install:
 
 install:
   - $SH "apt update"
-  - $SH "apt install -y pkg-config libsystemd-dev libjsoncpp-dev googletest meson clang-format"
+  - $SH "apt install -y pkg-config libsystemd-dev libjsoncpp-dev googletest meson clang-format g++-8"
 
 notifications:
   irc:

--- a/build-from-github.sh
+++ b/build-from-github.sh
@@ -8,6 +8,9 @@ OUTDIR=build
 rm -f $COMPATIBILITY_SYMLINK
 ln -s . $COMPATIBILITY_SYMLINK
 
+# Force usage of new compiler. This is a hack until we use a newer ubuntu
+# image (with newer compiler defaults)
+ln -f -s $(which g++-8) $(which g++)
 
 meson $OUTDIR
 ninja -C $OUTDIR test


### PR DESCRIPTION
We need a newer compiler to use designated assignments for structs.
The feature technically slated for c++20 but it'd be better to just
go ahead and depend on that versus hacking together macros to recreate
the feature.