### PR TITLE
Fix example config invalid

### DIFF
--- a/etc/desktop.json
+++ b/etc/desktop.json
@@ -28,6 +28,7 @@
                     {
                         "name": "memory_reclaim",
                         "args": {
+                            "cgroup": "user.slice/user-*.slice/session-*.scope,user.slice/user-*.slice/user@*.service/*,system.slice/*",
                             "duration": "10"
                         }
                     }


### PR DESCRIPTION
Example config does not pass validation, as `cgroup` args is required by `memory_reclaim`.