### PR TITLE
Fix open source build

### DIFF
--- a/config/ConfigCompilerTest.cpp
+++ b/config/ConfigCompilerTest.cpp
@@ -378,11 +378,13 @@ TEST_F(DropInCompilerTest, DisablesBase) {
   IR::Action increment;
   increment.name = "IncrementCount";
   IR::DetectorGroup dg{"dg", {cont}};
-  IR::Ruleset rs{
-      "rs",
-      {dg},
-      {increment},
-      IR::DropIn{.actiongroup_enabled = true, .disable_on_drop_in = true}};
+  IR::Ruleset rs{"rs",
+                 {dg},
+                 {increment},
+                 IR::DropIn{
+                     .disable_on_drop_in = true,
+                     .actiongroup_enabled = true,
+                 }};
   root.rulesets.emplace_back(std::move(rs));
 
   IR::Ruleset dropin_rs;
@@ -415,9 +417,11 @@ TEST_F(DropInCompilerTest, PermissionDenied) {
   IR::Ruleset rs{"rs",
                  {dg},
                  {increment},
-                 IR::DropIn{.detectorgroups_enabled = false,
-                            .actiongroup_enabled = false,
-                            .disable_on_drop_in = false}};
+                 IR::DropIn{
+                     .disable_on_drop_in = false,
+                     .detectorgroups_enabled = false,
+                     .actiongroup_enabled = false,
+                 }};
   root.rulesets.emplace_back(std::move(rs));
 
   IR::Ruleset dropin_rs;
@@ -480,16 +484,20 @@ TEST_F(DropInCompilerTest, MultipleRulesetDropin) {
   IR::Action noop;
   noop.name = "Continue";
   IR::DetectorGroup dg{"dg", {cont}};
-  IR::Ruleset rs{
-      "rs",
-      {dg},
-      {noop},
-      IR::DropIn{.actiongroup_enabled = true, .disable_on_drop_in = true}};
-  IR::Ruleset rs2{
-      "rs2",
-      {dg},
-      {noop},
-      IR::DropIn{.actiongroup_enabled = true, .disable_on_drop_in = true}};
+  IR::Ruleset rs{"rs",
+                 {dg},
+                 {noop},
+                 IR::DropIn{
+                     .disable_on_drop_in = true,
+                     .actiongroup_enabled = true,
+                 }};
+  IR::Ruleset rs2{"rs2",
+                  {dg},
+                  {noop},
+                  IR::DropIn{
+                      .disable_on_drop_in = true,
+                      .actiongroup_enabled = true,
+                  }};
   root.rulesets.emplace_back(std::move(rs));
   root.rulesets.emplace_back(std::move(rs2));
 

--- a/meson.build
+++ b/meson.build
@@ -2,7 +2,7 @@ project('oomd', 'cpp',
   version : '0.1.0',
   license : 'GPL2')
 
-cpp_args = ['-std=c++14', '-g', '-rdynamic']
+cpp_args = ['-std=c++17', '-g', '-rdynamic']
 
 # The ".." include path is necessary if one
 # does not want to build via the "build-from-github.sh" script.
@@ -110,6 +110,7 @@ if gtest_dep.found() and gmock_dep.found()
         test_executable = executable('oomd_' + executable_name_suffix,
             sources,
             include_directories : inc,
+            cpp_args : cpp_args,
             dependencies : deps,
             link_with : oomd_lib)
         test(executable_name_suffix, test_executable)


### PR DESCRIPTION
std::optional and designated struct initialization threw off the open
source build. This patch fixes things up.