### PR TITLE
Make optional features user-configurable at build-time

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,13 +30,14 @@ Note that oomd requires PSI to function. This kernel feature has been merged
 into the 4.20 release.
 
 oomd currently depends on [meson][2] and [jsoncpp][4]. [libsystemd][6] is an
-optional dependency.
+optional dependency. It can be forcibly enabled by passing `-Dsystemd=enabled`
+to meson, or disabled with `-Dsystemd=disabled`.
 
 oomd also requires GCC 8+ or clang 6+. Other compilers have not been tested.
 
     $ git clone https://github.com/facebookincubator/oomd
     $ cd oomd
-    $ meson build && ninja -C build
+    $ meson build -Dsystemd=enabled && ninja -C build
     $ cd build && sudo ninja install
 
 ## Configuration
@@ -53,10 +54,12 @@ oomd depends on [gtest/gmock][5] to run tests. Installing gtest/gmock from maste
 is preferred.
 
 If meson detects gtest/gmock is installed, meson will generate build rules for tests.
+They can also be forcibly enabled by passing `-Dtest=enabled` to meson, or disabled
+with `-Dtest=disabled`.
 
     $ cd oomd
     $ rm -rf build
-    $ meson build && ninja test -C build
+    $ meson build -Dtest=enabled && ninja test -C build
 
 ## Writing custom plugins
 

--- a/meson.build
+++ b/meson.build
@@ -48,7 +48,7 @@ deps = [dependency('jsoncpp'),
         dependency('threads')]
 
 # Optional dependencies
-systemd_dep = dependency('libsystemd', required: false)
+systemd_dep = dependency('libsystemd', required: get_option('systemd'))
 if systemd_dep.found()
   srcs += files('''
       plugins/systemd/BaseSystemdPlugin.cpp
@@ -96,8 +96,8 @@ if systemd_dep.found()
 endif
 
 
-gtest_dep = dependency('gtest', main : true, required : false)
-gmock_dep = dependency('gmock', required : false)
+gtest_dep = dependency('gtest', main : true, required : get_option('test'))
+gmock_dep = dependency('gmock', required : get_option('test'))
 if gtest_dep.found() and gmock_dep.found()
     deps += [gtest_dep, gmock_dep]
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,2 @@
+option('systemd', type: 'feature', description: 'Include support for systemd')
+option('test', type: 'feature', description: 'Enable the test suite')


### PR DESCRIPTION
Currently `oomd`'s meson configuration relies on automatic discovery of optional dependencies, namely systemd and gtest/gmock. It's possible that someone building `oomd` (say a package maintainer for a major distribution) might not want to add systemd support despite libsystemd is available on their system, or doesn't want to build nor run the test suite despite gtest is available on their system; or maybe they want to make sure they're enabled and would like the build to fail if these dependencies are missing; or `oomd` is being packaged for a source-based distro and automatic discovery will introduce bizarre problems if a dependency is detected at build-time but missing at runtime.

This fixes that.

I wasn't sure how to make it clear how to use the new options so I added them to the suggested build procedures in `README.md`. They can be omitted and the build system will behave exactly the same as before.