### PR TITLE
Clean up util/Fs

### DIFF
--- a/include/CgroupPath.cpp
+++ b/include/CgroupPath.cpp
@@ -20,6 +20,7 @@
 #include <exception>
 
 #include "oomd/util/Fs.h"
+#include "oomd/util/Util.h"
 
 namespace Oomd {
 
@@ -32,7 +33,7 @@ CgroupPath::CgroupPath(
     cgroup_fs_.pop_back();
   }
 
-  cgroup_path_ = Fs::split(cgroup_path, '/');
+  cgroup_path_ = Util::split(cgroup_path, '/');
   recomputeReadCache();
 }
 
@@ -67,7 +68,7 @@ CgroupPath CgroupPath::getParent() const {
 CgroupPath CgroupPath::getChild(const std::string& path) const {
   CgroupPath child(*this);
 
-  auto pieces = Fs::split(path, '/');
+  auto pieces = Util::split(path, '/');
   child.cgroup_path_.reserve(child.cgroup_path_.size() + pieces.size());
   for (auto& piece : pieces) {
     child.cgroup_path_.emplace_back(std::move(piece));

--- a/plugins/AdjustCgroup.cpp
+++ b/plugins/AdjustCgroup.cpp
@@ -40,7 +40,7 @@ int AdjustCgroup::init(
         (args.find("cgroup_fs") != args.end() ? args.at("cgroup_fs")
                                               : kCgroupFs);
 
-    auto cgroups = Fs::split(args.at("cgroup"), ',');
+    auto cgroups = Util::split(args.at("cgroup"), ',');
     for (const auto& c : cgroups) {
       resources.emplace(cgroup_fs, c);
       cgroups_.emplace(cgroup_fs, c);

--- a/plugins/DumpCgroupOverview.cpp
+++ b/plugins/DumpCgroupOverview.cpp
@@ -23,6 +23,7 @@
 #include "oomd/Log.h"
 #include "oomd/PluginRegistry.h"
 #include "oomd/util/Fs.h"
+#include "oomd/util/Util.h"
 
 namespace {
 auto constexpr kCgroupFs = "/sys/fs/cgroup";
@@ -65,7 +66,7 @@ int DumpCgroupOverview::init(
     auto cgroup_fs =
         (args.find("cgroup_fs") != args.end() ? args.at("cgroup_fs")
                                               : kCgroupFs);
-    auto cgroups = Fs::split(args.at("cgroup"), ',');
+    auto cgroups = Util::split(args.at("cgroup"), ',');
     for (const auto& c : cgroups) {
       cgroups_.emplace(cgroup_fs, c);
     }

--- a/plugins/KillMemoryGrowth-inl.h
+++ b/plugins/KillMemoryGrowth-inl.h
@@ -26,6 +26,7 @@
 #include "oomd/PluginRegistry.h"
 #include "oomd/include/Types.h"
 #include "oomd/util/Fs.h"
+#include "oomd/util/Util.h"
 
 namespace {
 auto constexpr kCgroupFs = "/sys/fs/cgroup";
@@ -42,7 +43,7 @@ int KillMemoryGrowth<Base>::init(
         (args.find("cgroup_fs") != args.end() ? args.at("cgroup_fs")
                                               : kCgroupFs);
 
-    auto cgroups = Fs::split(args.at("cgroup"), ',');
+    auto cgroups = Util::split(args.at("cgroup"), ',');
     for (const auto& c : cgroups) {
       resources.emplace(cgroup_fs, c);
       cgroups_.emplace(cgroup_fs, c);

--- a/plugins/KillPressure-inl.h
+++ b/plugins/KillPressure-inl.h
@@ -25,6 +25,7 @@
 #include "oomd/Log.h"
 #include "oomd/include/Types.h"
 #include "oomd/util/Fs.h"
+#include "oomd/util/Util.h"
 
 namespace Oomd {
 
@@ -37,7 +38,7 @@ int KillPressure<Base>::init(
         (args.find("cgroup_fs") != args.end() ? args.at("cgroup_fs")
                                               : kCgroupFs);
 
-    auto cgroups = Fs::split(args.at("cgroup"), ',');
+    auto cgroups = Util::split(args.at("cgroup"), ',');
     for (const auto& c : cgroups) {
       resources.emplace(cgroup_fs, c);
       cgroups_.emplace(cgroup_fs, c);

--- a/plugins/KillSwapUsage-inl.h
+++ b/plugins/KillSwapUsage-inl.h
@@ -25,6 +25,7 @@
 #include "oomd/Log.h"
 #include "oomd/include/Types.h"
 #include "oomd/util/Fs.h"
+#include "oomd/util/Util.h"
 
 namespace Oomd {
 
@@ -37,7 +38,7 @@ int KillSwapUsage<Base>::init(
         (args.find("cgroup_fs") != args.end() ? args.at("cgroup_fs")
                                               : kCgroupFs);
 
-    auto cgroups = Fs::split(args.at("cgroup"), ',');
+    auto cgroups = Util::split(args.at("cgroup"), ',');
     for (const auto& c : cgroups) {
       resources.emplace(cgroup_fs, c);
       cgroups_.emplace(cgroup_fs, c);

--- a/plugins/MemoryAbove.cpp
+++ b/plugins/MemoryAbove.cpp
@@ -66,7 +66,7 @@ int MemoryAbove::init(
         (args.find("cgroup_fs") != args.end() ? args.at("cgroup_fs")
                                               : kCgroupFs);
 
-    auto cgroups = Fs::split(args.at("cgroup"), ',');
+    auto cgroups = Util::split(args.at("cgroup"), ',');
     for (const auto& c : cgroups) {
       resources.emplace(cgroup_fs, c);
       cgroups_.emplace(cgroup_fs, c);

--- a/plugins/MemoryReclaim.cpp
+++ b/plugins/MemoryReclaim.cpp
@@ -21,6 +21,7 @@
 #include "oomd/PluginRegistry.h"
 #include "oomd/util/Fs.h"
 #include "oomd/util/ScopeGuard.h"
+#include "oomd/util/Util.h"
 
 static constexpr auto kCgroupFs = "/sys/fs/cgroup/";
 static constexpr auto kPgscan = "pgscan";
@@ -37,7 +38,7 @@ int MemoryReclaim::init(
         (args.find("cgroup_fs") != args.end() ? args.at("cgroup_fs")
                                               : kCgroupFs);
 
-    auto cgroups = Fs::split(args.at("cgroup"), ',');
+    auto cgroups = Util::split(args.at("cgroup"), ',');
     for (const auto& c : cgroups) {
       cgroups_.emplace(cgroup_fs, c);
     }

--- a/plugins/PressureAbove.cpp
+++ b/plugins/PressureAbove.cpp
@@ -24,6 +24,7 @@
 #include "oomd/PluginRegistry.h"
 #include "oomd/util/Fs.h"
 #include "oomd/util/ScopeGuard.h"
+#include "oomd/util/Util.h"
 
 static constexpr auto kCgroupFs = "/sys/fs/cgroup/";
 
@@ -38,7 +39,7 @@ int PressureAbove::init(
     auto cgroup_fs =
         (args.find("cgroup_fs") != args.end() ? args.at("cgroup_fs")
                                               : kCgroupFs);
-    auto cgroups = Fs::split(args.at("cgroup"), ',');
+    auto cgroups = Util::split(args.at("cgroup"), ',');
     for (const auto& c : cgroups) {
       cgroups_.emplace(cgroup_fs, c);
     }

--- a/plugins/PressureRisingBeyond.cpp
+++ b/plugins/PressureRisingBeyond.cpp
@@ -24,6 +24,7 @@
 #include "oomd/PluginRegistry.h"
 #include "oomd/util/Fs.h"
 #include "oomd/util/ScopeGuard.h"
+#include "oomd/util/Util.h"
 
 static constexpr auto kCgroupFs = "/sys/fs/cgroup";
 
@@ -38,7 +39,7 @@ int PressureRisingBeyond::init(
     auto cgroup_fs =
         (args.find("cgroup_fs") != args.end() ? args.at("cgroup_fs")
                                               : kCgroupFs);
-    auto cgroups = Fs::split(args.at("cgroup"), ',');
+    auto cgroups = Util::split(args.at("cgroup"), ',');
     for (const auto& c : cgroups) {
       cgroups_.emplace(cgroup_fs, c);
     }

--- a/plugins/SwapFree.cpp
+++ b/plugins/SwapFree.cpp
@@ -21,6 +21,7 @@
 #include "oomd/PluginRegistry.h"
 #include "oomd/include/Assert.h"
 #include "oomd/util/Fs.h"
+#include "oomd/util/Util.h"
 
 static auto constexpr kProcSwapsFile = "/proc/swaps";
 
@@ -55,7 +56,7 @@ Engine::PluginRet SwapFree::run(OomdContext& /* unused */) {
 
   // For each swap, tally up used and total
   for (size_t i = 1; i < swaps.size(); ++i) {
-    auto parts = Fs::split(swaps[i], '\t');
+    auto parts = Util::split(swaps[i], '\t');
     // The /proc/swaps format is pretty bad. The first field is padded by
     // spaces but the rest of the fields are padded by '\t'. Since we don't
     // really care about the first field, we'll just split by '\t'.

--- a/util/Fs.cpp
+++ b/util/Fs.cpp
@@ -26,11 +26,11 @@
 
 #include <deque>
 #include <fstream>
-#include <sstream>
 #include <utility>
 
 #include "oomd/Log.h"
 #include "oomd/include/Assert.h"
+#include "oomd/util/Util.h"
 
 namespace Oomd {
 
@@ -94,7 +94,7 @@ std::unordered_set<std::string> Fs::resolveWildcardPath(
     return ret;
   }
 
-  auto parts = split(path, '/');
+  auto parts = Util::split(path, '/');
   std::deque<std::pair<std::string, size_t>> queue;
   // Add initial path piece to begin search on. Start at root
   // if provided path is absolute, else go with relative dir.
@@ -143,18 +143,6 @@ std::unordered_set<std::string> Fs::resolveWildcardPath(
   return ret;
 }
 
-std::vector<std::string> Fs::split(const std::string& line, char delim) {
-  std::istringstream iss(line);
-  std::string item;
-  std::vector<std::string> ret;
-  while (std::getline(iss, item, delim)) {
-    if (item.size()) {
-      ret.push_back(std::move(item));
-    }
-  }
-  return ret;
-}
-
 void Fs::removePrefix(std::string& str, const std::string& prefix) {
   if (str.find(prefix) != std::string::npos) {
     // Strip the leading './' if it exists and we haven't been explicitly
@@ -195,7 +183,7 @@ std::vector<std::string> Fs::readControllers(const std::string& path) {
     return controllers;
   }
 
-  controllers = split(lines[0], ' ');
+  controllers = Util::split(lines[0], ' ');
 
   return controllers;
 }
@@ -254,19 +242,20 @@ ResourcePressure Fs::readRespressure(
     //
     // some avg10=0.22 avg60=0.17 avg300=1.11 total=58761459
     // full avg10=0.22 avg60=0.16 avg300=1.08 total=58464525
-    std::vector<std::string> toks = split(lines[pressure_line_index], ' ');
+    std::vector<std::string> toks =
+        Util::split(lines[pressure_line_index], ' ');
     OCHECK_EXCEPT(
         toks[0] == type_name, bad_control_file(path + ": invalid format"));
-    std::vector<std::string> avg10 = split(toks[1], '=');
+    std::vector<std::string> avg10 = Util::split(toks[1], '=');
     OCHECK_EXCEPT(
         avg10[0] == "avg10", bad_control_file(path + ": invalid format"));
-    std::vector<std::string> avg60 = split(toks[2], '=');
+    std::vector<std::string> avg60 = Util::split(toks[2], '=');
     OCHECK_EXCEPT(
         avg60[0] == "avg60", bad_control_file(path + ": invalid format"));
-    std::vector<std::string> avg300 = split(toks[3], '=');
+    std::vector<std::string> avg300 = Util::split(toks[3], '=');
     OCHECK_EXCEPT(
         avg300[0] == "avg300", bad_control_file(path + ": invalid format"));
-    std::vector<std::string> total = split(toks[4], '=');
+    std::vector<std::string> total = Util::split(toks[4], '=');
     OCHECK_EXCEPT(
         total[0] == "total", bad_control_file(path + ": invalid format"));
 
@@ -282,7 +271,8 @@ ResourcePressure Fs::readRespressure(
     // aggr 316016073
     // some 0.00 0.03 0.05
     // full 0.00 0.03 0.05
-    std::vector<std::string> toks = split(lines[pressure_line_index + 1], ' ');
+    std::vector<std::string> toks =
+        Util::split(lines[pressure_line_index + 1], ' ');
     OCHECK_EXCEPT(
         toks[0] == type_name, bad_control_file(path + ": invalid format"));
 
@@ -464,8 +454,8 @@ bool Fs::isUnderParentPath(
     return false;
   }
 
-  auto parent_parts = split(parent_path, '/');
-  auto path_parts = split(path, '/');
+  auto parent_parts = Util::split(parent_path, '/');
+  auto path_parts = Util::split(path, '/');
   int i = 0;
 
   if (path_parts.size() < parent_parts.size()) {
@@ -484,7 +474,7 @@ bool Fs::isUnderParentPath(
 std::string Fs::getCgroup2MountPoint(const std::string& path) {
   auto lines = readFileByLine(path);
   for (auto& line : lines) {
-    auto parts = split(line, ' ');
+    auto parts = Util::split(line, ' ');
     if (parts.size() > 1) {
       if (parts[0] == "cgroup2") {
         return parts[1] + '/';

--- a/util/Fs.h
+++ b/util/Fs.h
@@ -78,9 +78,6 @@ class Fs {
   static std::unordered_set<std::string> resolveWildcardPath(
       const std::string& path);
 
-  /* Split string into tokens by delim */
-  static std::vector<std::string> split(const std::string& line, char delim);
-
   /*
    * Path aware prefix removal.
    *

--- a/util/FsTest.cpp
+++ b/util/FsTest.cpp
@@ -67,28 +67,6 @@ TEST_F(FsTest, IsDir) {
   EXPECT_FALSE(Fs::isDir(dir + "/NOTINFS"));
 }
 
-TEST_F(FsTest, Split) {
-  auto toks = Fs::split("one by two", ' ');
-  ASSERT_EQ(toks.size(), 3);
-  EXPECT_TRUE(existsInVec(toks, "one"));
-  EXPECT_TRUE(existsInVec(toks, "by"));
-  EXPECT_TRUE(existsInVec(toks, "two"));
-
-  toks = Fs::split(" by two", ' ');
-  ASSERT_EQ(toks.size(), 2);
-  EXPECT_TRUE(existsInVec(toks, "by"));
-  EXPECT_TRUE(existsInVec(toks, "two"));
-
-  toks = Fs::split("     by        two", ' ');
-  ASSERT_EQ(toks.size(), 2);
-  EXPECT_TRUE(existsInVec(toks, "by"));
-  EXPECT_TRUE(existsInVec(toks, "two"));
-
-  toks = Fs::split("one two three", ',');
-  ASSERT_EQ(toks.size(), 1);
-  EXPECT_EQ(toks[0], "one two three");
-}
-
 TEST_F(FsTest, RemovePrefix) {
   std::string s = "long string like this";
   Fs::removePrefix(s, "long string ");

--- a/util/Util.cpp
+++ b/util/Util.cpp
@@ -15,9 +15,10 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#include <algorithm>
-
 #include "oomd/util/Util.h"
+
+#include <algorithm>
+#include <sstream>
 
 namespace Oomd {
 
@@ -91,6 +92,18 @@ int Util::parseSize(const std::string& input, int64_t* output) {
   }
   *output = is_neg ? -size : size;
   return 0;
+}
+
+std::vector<std::string> Util::split(const std::string& line, char delim) {
+  std::istringstream iss(line);
+  std::string item;
+  std::vector<std::string> ret;
+  while (std::getline(iss, item, delim)) {
+    if (item.size()) {
+      ret.push_back(std::move(item));
+    }
+  }
+  return ret;
 }
 
 } // namespace Oomd

--- a/util/Util.h
+++ b/util/Util.h
@@ -19,12 +19,16 @@
 
 #include <cstdint>
 #include <string>
+#include <vector>
 
 namespace Oomd {
 
 class Util {
  public:
   static int parseSize(const std::string& input, int64_t* output);
+
+  /* Split string into tokens by delim */
+  static std::vector<std::string> split(const std::string& line, char delim);
 };
 
 } // namespace Oomd

--- a/util/UtilTest.cpp
+++ b/util/UtilTest.cpp
@@ -23,7 +23,7 @@
 using namespace Oomd;
 using namespace testing;
 
-TEST(ParseSizeTest, ParseSizeTest) {
+TEST(UtilTest, ParseSizeTest) {
   int64_t v;
 
   EXPECT_EQ(Util::parseSize("8192", &v), 0);
@@ -38,4 +38,26 @@ TEST(ParseSizeTest, ParseSizeTest) {
   EXPECT_EQ(Util::parseSize("1.5MK", &v), -1);
   EXPECT_EQ(Util::parseSize("??", &v), -1);
   EXPECT_EQ(Util::parseSize("+-123M", &v), -1);
+}
+
+TEST(UtilTest, Split) {
+  auto toks = Util::split("one by two", ' ');
+  ASSERT_EQ(toks.size(), 3);
+  EXPECT_THAT(toks, Contains("one"));
+  EXPECT_THAT(toks, Contains("by"));
+  EXPECT_THAT(toks, Contains("two"));
+
+  toks = Util::split(" by two", ' ');
+  ASSERT_EQ(toks.size(), 2);
+  EXPECT_THAT(toks, Contains("by"));
+  EXPECT_THAT(toks, Contains("two"));
+
+  toks = Util::split("     by        two", ' ');
+  ASSERT_EQ(toks.size(), 2);
+  EXPECT_THAT(toks, Contains("by"));
+  EXPECT_THAT(toks, Contains("two"));
+
+  toks = Util::split("one two three", ',');
+  ASSERT_EQ(toks.size(), 1);
+  EXPECT_EQ(toks[0], "one two three");
 }


### PR DESCRIPTION
* Move Fs::split to Util::split because string handling routines don't really belong with filesystem helpers
* Use gtest helpers instead of our own helpers

Test plan: unit tests