### PR TITLE
Make dump_cgroup_overview pull data from core oomd

### DIFF
--- a/plugins/DumpCgroupOverview.cpp
+++ b/plugins/DumpCgroupOverview.cpp
@@ -18,10 +18,12 @@
 #include "oomd/plugins/DumpCgroupOverview.h"
 
 #include <iomanip>
+#include <exception>
 #include <sstream>
 
 #include "oomd/Log.h"
 #include "oomd/PluginRegistry.h"
+#include "oomd/include/CgroupPath.h"
 #include "oomd/util/Fs.h"
 #include "oomd/util/Util.h"
 
@@ -30,15 +32,18 @@ auto constexpr kCgroupFs = "/sys/fs/cgroup";
 auto constexpr kPgscanSwap = "pgscan_kswapd";
 auto constexpr kPgscanDirect = "pgscan_direct";
 
-void dumpCgroupOverview(const std::string& absolute_cgroup_path, bool always) {
+void dumpCgroupOverview(
+    const Oomd::CgroupPath& path,
+    const Oomd::CgroupContext& cgroup_ctx,
+    bool always) {
   // Only log on exceptional cases
-  const auto pressure = Oomd::Fs::readMempressure(absolute_cgroup_path);
+  const auto& pressure = cgroup_ctx.pressure;
   bool should_dump = (always || (pressure.sec_10 >= 1 && pressure.sec_60 > 0));
   if (!should_dump) {
     return;
   }
 
-  const int64_t current = Oomd::Fs::readMemcurrent(absolute_cgroup_path);
+  const int64_t current = cgroup_ctx.current_usage;
   auto meminfo = Oomd::Fs::getMeminfo();
   const int64_t swapfree = meminfo["SwapFree"];
   const int64_t swaptotal = meminfo["SwapTotal"];
@@ -47,7 +52,7 @@ void dumpCgroupOverview(const std::string& absolute_cgroup_path, bool always) {
 
   std::ostringstream oss;
   oss << std::setprecision(2) << std::fixed;
-  oss << "cgroup=" << absolute_cgroup_path << " total=" << current / 1024 / 1024
+  oss << "cgroup=" << path.relativePath() << " total=" << current / 1024 / 1024
       << "MB pressure=" << pressure.sec_10 << ":" << pressure.sec_60 << ":"
       << pressure.sec_600 << " swapfree=" << swapfree / 1024 / 1024 << "MB/"
       << swaptotal / 1024 / 1024 << "MB pgscan=" << pgscan;
@@ -85,15 +90,21 @@ int DumpCgroupOverview::init(
   return 0;
 }
 
-Engine::PluginRet DumpCgroupOverview::run(OomdContext& /* unused */) {
-  std::unordered_set<std::string> resolved_cgroups;
+Engine::PluginRet DumpCgroupOverview::run(OomdContext& ctx) {
+  std::unordered_set<CgroupPath> resolved_cgroups;
   for (const auto& cgroup : cgroups_) {
-    auto resolved = Fs::resolveWildcardPath(cgroup.absolutePath());
+    auto resolved = Fs::resolveCgroupWildcardPath(cgroup);
     resolved_cgroups.insert(resolved.begin(), resolved.end());
   }
 
   for (const auto& resolved : resolved_cgroups) {
-    dumpCgroupOverview(resolved, always_);
+    try {
+      const CgroupContext& cgroup_ctx = ctx.getCgroupContext(resolved);
+      dumpCgroupOverview(resolved, cgroup_ctx, always_);
+    } catch (const std::invalid_argument& ex) {
+      // cgroup is ignored or ommitted
+      continue;
+    }
   }
 
   return Engine::PluginRet::CONTINUE;

--- a/util/Fs.h
+++ b/util/Fs.h
@@ -23,6 +23,7 @@
 #include <unordered_set>
 #include <vector>
 
+#include "oomd/include/CgroupPath.h"
 #include "oomd/include/Types.h"
 
 namespace Oomd {
@@ -77,6 +78,8 @@ class Fs {
    */
   static std::unordered_set<std::string> resolveWildcardPath(
       const std::string& path);
+  static std::unordered_set<CgroupPath> resolveCgroupWildcardPath(
+      const CgroupPath& path);
 
   /*
    * Path aware prefix removal.

--- a/util/FsTest.cpp
+++ b/util/FsTest.cpp
@@ -91,22 +91,17 @@ TEST(FsTest, ResolveWildcardedPathRelative) {
   std::string wildcarded_path_some = "/this/path/is*/going/to/be/long/file";
   auto resolved = Fs::resolveWildcardPath(dir + wildcarded_path_some);
   ASSERT_EQ(resolved.size(), 2);
+  EXPECT_THAT(resolved, Contains(dir + "/this/path/is/going/to/be/long/file"));
   EXPECT_THAT(
-      resolved, Contains("./" + dir + "/this/path/is/going/to/be/long/file"));
-  EXPECT_THAT(
-      resolved,
-      Contains("./" + dir + "/this/path/isNOT/going/to/be/long/file"));
+      resolved, Contains(dir + "/this/path/isNOT/going/to/be/long/file"));
 
   std::string wildcarded_path_all = "/this/path/*/going/to/be/long/file";
   resolved = Fs::resolveWildcardPath(dir + wildcarded_path_all);
   ASSERT_EQ(resolved.size(), 3);
+  EXPECT_THAT(resolved, Contains(dir + "/this/path/is/going/to/be/long/file"));
   EXPECT_THAT(
-      resolved, Contains("./" + dir + "/this/path/is/going/to/be/long/file"));
-  EXPECT_THAT(
-      resolved,
-      Contains("./" + dir + "/this/path/isNOT/going/to/be/long/file"));
-  EXPECT_THAT(
-      resolved, Contains("./" + dir + "/this/path/WAH/going/to/be/long/file"));
+      resolved, Contains(dir + "/this/path/isNOT/going/to/be/long/file"));
+  EXPECT_THAT(resolved, Contains(dir + "/this/path/WAH/going/to/be/long/file"));
 
   resolved = Fs::resolveWildcardPath(dir + "/not/a/valid/dir");
   ASSERT_EQ(resolved.size(), 0);
@@ -117,6 +112,32 @@ TEST(FsTest, ResolveWildcardedPathAbsolute) {
   ASSERT_EQ(resolved.size(), 2);
   EXPECT_THAT(resolved, Contains("/proc/vmstat"));
   EXPECT_THAT(resolved, Contains("/proc/vmallocinfo"));
+}
+
+TEST(FsTest, ResolveCgroupWildcardPath) {
+  std::string root_fs(kFsDataDir);
+  root_fs += "/wildcard";
+
+  auto resolved = Fs::resolveCgroupWildcardPath(
+      CgroupPath{root_fs, "/this/path/is*/going/to/be/long/file"});
+  ASSERT_EQ(resolved.size(), 2);
+
+  EXPECT_THAT(
+      resolved,
+      Contains(CgroupPath(root_fs, "/this/path/is/going/to/be/long/file")));
+  EXPECT_THAT(
+      resolved,
+      Contains(CgroupPath(root_fs, "/this/path/isNOT/going/to/be/long/file")));
+
+  // Verify root_fs is correctly separated from relative path
+  auto it_one =
+      resolved.find(CgroupPath(root_fs, "/this/path/is/going/to/be/long/file"));
+  ASSERT_NE(it_one, resolved.end());
+  EXPECT_EQ(it_one->cgroupFs(), root_fs);
+  auto it_two = resolved.find(
+      CgroupPath(root_fs, "/this/path/isNOT/going/to/be/long/file"));
+  ASSERT_NE(it_two, resolved.end());
+  EXPECT_EQ(it_two->cgroupFs(), root_fs);
 }
 
 TEST(FsTest, ReadFile) {


### PR DESCRIPTION
Two commits in this PR. One to add another Fs:: helper, another
to make `dump_cgroup_overview` get data from core oomd.

Changes:
* Add helper to resolve CgroupPaths. This will help simplify plugin
logic later on.
* resolveWildcardPath would sometimes prefix resolved paths with "./".
This is ugly and unexpected. Clean up those prefixes.
* Independently pulling cgroup data using Fs::* duplicates effort and
causes errors checks to be duplicated. Prefer using data pulled by
core instead.