### PR TITLE
Fix "explicit specialization in non-namespace scope" compiler error

### DIFF
--- a/Log.cpp
+++ b/Log.cpp
@@ -190,4 +190,20 @@ void Log::ioThread(std::ostream& debug_sink) {
   }
 }
 
+template <>
+LogStream& LogStream::operator<<<LogStream::Control>(const Control& ctrl) {
+  switch (ctrl) {
+    case Control::DISABLE:
+      enabled() = false;
+      break;
+    case Control::ENABLE:
+      skip_ = true;
+      enabled() = true;
+      break;
+
+      // Missing default to protect against future enum vals
+  }
+
+  return *this;
+}
 } // namespace Oomd

--- a/Log.h
+++ b/Log.h
@@ -102,29 +102,17 @@ class LogStream {
     return *this;
   }
 
-  template <>
-  LogStream& operator<<<Control>(const Control& ctrl) {
-    switch (ctrl) {
-      case Control::DISABLE:
-        enabled() = false;
-        break;
-      case Control::ENABLE:
-        skip_ = true;
-        enabled() = true;
-        break;
-
-        // Missing default to protect against future enum vals
-    }
-
-    return *this;
-  }
-
  private:
   static bool& enabled();
   // Set this flag to skip processing this log message
   bool skip_{false};
   std::ostringstream stream_;
 };
+
+// Must declare explicit specialization in *namespace* scope (class scope
+// doesn't count) for some weird reason according to the C++ spec.
+template <>
+LogStream& LogStream::operator<<<LogStream::Control>(const Control& ctrl);
 
 template <typename... Args>
 static void OOMD_KMSG_LOG(Args&&... args) {


### PR DESCRIPTION
Templates must be declared/defined in a namespace scope. I guess class
scope doesn't count. Strange decision on C++'s part.