### PR TITLE
Fix build warnings

### DIFF
--- a/Oomd.cpp
+++ b/Oomd.cpp
@@ -431,7 +431,7 @@ void Oomd::processDropInAdd(const std::string& file) {
   }
 
   size_t tag = std::hash<std::string>{}(file);
-  for (int i = 0; i < unit->rulesets.size(); ++i) {
+  for (size_t i = 0; i < unit->rulesets.size(); ++i) {
     if (engine_->addDropInConfig(tag, std::move(unit->rulesets.at(i)))) {
       resources_.insert(unit->resources.cbegin(), unit->resources.cend());
     } else {

--- a/util/Fs.cpp
+++ b/util/Fs.cpp
@@ -355,6 +355,9 @@ ResourcePressure Fs::readRespressure(
     case PsiFormat::INVALID:
       throw bad_control_file(path + ": invalid format");
   }
+
+  // To silence g++ compiler warning about enums
+  throw std::runtime_error("Not all enums handled");
 }
 
 int64_t Fs::readMemcurrent(const std::string& path) {


### PR DESCRIPTION
Yes, there is a bit of code duplication. I think this is better than the alternative
of creating a protected method in `StatsClient` or something and then some
test class deriving and making public the helper. We can't just chuck this helper
in Util.h either b/c Util.h is not allowed to use OLOG and we don't _always_ want
output directly printed to stdout/stderr.

This closes #77.

Previous warnings:
```
$  ~/dev/oomd git:(master) ✗ ninja -C build
ninja: Entering directory `build'
[0/1] Regenerating build files.
The Meson build system
Version: 0.50.0
Source dir: /home/dlxu/dev/oomd
Build dir: /home/dlxu/dev/oomd/build
Build type: native build
Project name: oomd
Project version: 0.1.0
Native C++ compiler: c++ (gcc 8.3.1 "c++ (GCC) 8.3.1 20190223 (Red Hat 8.3.1-2)")
Build machine cpu family: x86_64
Build machine cpu: x86_64
Dependency jsoncpp found: YES (cached)
Dependency threads found: YES (cached)
Dependency libsystemd found: YES (cached)
Dependency gtest found: YES (cached)
Dependency gmock found: YES (cached)
Build targets in project: 13
Found ninja-1.8.2 at /usr/bin/ninja
[9/59] Compiling C++ object 'oomd@sha/StatsClient.cpp.o'.
../StatsClient.cpp: In member function ‘std::optional<std::unordered_map<std::__cxx11::basic_string<char>, int> > Oomd::StatsClient::getStats()’:
../StatsClient.cpp:45:16: warning: ‘Reader’ is deprecated: Use CharReader and CharReaderBuilder instead [-Wdeprecated-declarations]
   Json::Reader reader;
                ^~~~~~
In file included from ../StatsClient.cpp:19:
/usr/include/json/reader.h:35:83: note: declared here
 class JSONCPP_DEPRECATED("Use CharReader and CharReaderBuilder instead") JSON_API Reader {
                                                                                   ^~~~~~
../StatsClient.cpp: In member function ‘int Oomd::StatsClient::resetStats()’:
../StatsClient.cpp:75:16: warning: ‘Reader’ is deprecated: Use CharReader and CharReaderBuilder instead [-Wdeprecated-declarations]
   Json::Reader reader;
                ^~~~~~
In file included from ../StatsClient.cpp:19:
/usr/include/json/reader.h:35:83: note: declared here
 class JSONCPP_DEPRECATED("Use CharReader and CharReaderBuilder instead") JSON_API Reader {
                                                                                   ^~~~~~
../StatsClient.cpp: In member function ‘int Oomd::StatsClient::closeSocket()’:
../StatsClient.cpp:95:16: warning: ‘Reader’ is deprecated: Use CharReader and CharReaderBuilder instead [-Wdeprecated-declarations]
   Json::Reader reader;
                ^~~~~~
In file included from ../StatsClient.cpp:19:
/usr/include/json/reader.h:35:83: note: declared here
 class JSONCPP_DEPRECATED("Use CharReader and CharReaderBuilder instead") JSON_API Reader {
                                                                                   ^~~~~~
[33/59] Compiling C++ object 'oomd@sha/util_Fs.cpp.o'.
../util/Fs.cpp: In static member function ‘static Oomd::ResourcePressure Oomd::Fs::readRespressure(const string&, Oomd::Fs::PressureType)’:
../util/Fs.cpp:358:1: warning: control reaches end of non-void function [-Wreturn-type]
 }
 ^
[48/59] Compiling C++ object 'oomd_stats_tests@exe/StatsTest.cpp.o'.
../StatsTest.cpp: In member function ‘virtual void StatsTest_InvalidRequests_Test::TestBody()’:
../StatsTest.cpp:89:18: warning: ‘Reader’ is deprecated: Use CharReader and CharReaderBuilder instead [-Wdeprecated-declarations]
     Json::Reader reader;
                  ^~~~~~
In file included from ../StatsTest.cpp:21:
/usr/include/json/reader.h:35:83: note: declared here
 class JSONCPP_DEPRECATED("Use CharReader and CharReaderBuilder instead") JSON_API Reader {
                                                                                   ^~~~~~
../StatsTest.cpp:99:18: warning: ‘Reader’ is deprecated: Use CharReader and CharReaderBuilder instead [-Wdeprecated-declarations]
     Json::Reader reader;
                  ^~~~~~
In file included from ../StatsTest.cpp:21:
/usr/include/json/reader.h:35:83: note: declared here
 class JSONCPP_DEPRECATED("Use CharReader and CharReaderBuilder instead") JSON_API Reader {
                                                                                   ^~~~~~
../StatsTest.cpp:119:18: warning: ‘Reader’ is deprecated: Use CharReader and CharReaderBuilder instead [-Wdeprecated-declarations]
     Json::Reader reader;
                  ^~~~~~
In file included from ../StatsTest.cpp:21:
/usr/include/json/reader.h:35:83: note: declared here
 class JSONCPP_DEPRECATED("Use CharReader and CharReaderBuilder instead") JSON_API Reader {
                                                                                   ^~~~~~
../StatsTest.cpp:81:9: warning: unused variable ‘stats’ [-Wunused-variable]
   auto& stats = *(stats_ptr);
         ^~~~~
[59/59] Linking target oomd_plugin_tests.
```