### PR TITLE
Add --version flag

### DIFF
--- a/Main.cpp
+++ b/Main.cpp
@@ -38,6 +38,12 @@
 #include "oomd/include/Defines.h"
 #include "oomd/util/Fs.h"
 
+#ifdef MESON_BUILD
+#include "Version.h"
+#else
+#define GIT_VERSION "unknown"
+#endif
+
 static constexpr auto kConfigFilePath = "/etc/oomd.json";
 static constexpr auto kCgroupFsRoot = "/sys/fs/cgroup";
 static constexpr auto kSocketPath = "/run/oomd/oomd-stats.socket";
@@ -47,6 +53,7 @@ static void printUsage() {
       << "usage: oomd [OPTION]...\n\n"
          "optional arguments:\n"
          "  --help, -h                 Show this help message and exit\n"
+         "  --version                  Print version and exit\n"
          "  --config, -C CONFIG        Config file (default: /etc/oomd.json)\n"
          "  --interval, -i INTERVAL    Event loop polling interval (default: 5)\n"
          "  --cgroup-fs, -f FS         Cgroup2 filesystem mount point (default: /sys/fs/cgroup)\n"
@@ -115,9 +122,10 @@ int main(int argc, char** argv) {
   bool should_dump_stats = false;
   bool should_reset_stats = false;
 
-  const char* const short_options = "hC:w:i:f:c:ls:dr";
+  const char* const short_options = "hvC:w:i:f:c:ls:dr";
   option long_options[] = {
       option{"help", no_argument, nullptr, 'h'},
+      option{"version", no_argument, nullptr, 'v'},
       option{"config", required_argument, nullptr, 'C'},
       option{"interval", required_argument, nullptr, 'i'},
       option{"cgroup-fs", required_argument, nullptr, 'f'},
@@ -134,6 +142,9 @@ int main(int argc, char** argv) {
     switch (c) {
       case 'h':
         printUsage();
+        return 0;
+      case 'v':
+        std::cout << GIT_VERSION << std::endl;
         return 0;
       case 'C':
         flag_conf_file = std::string(optarg);

--- a/Main.cpp
+++ b/Main.cpp
@@ -39,7 +39,7 @@
 #include "oomd/util/Fs.h"
 
 #ifdef MESON_BUILD
-#include "Version.h"
+#include "Version.h" // @manual
 #else
 #define GIT_VERSION "unknown"
 #endif

--- a/Main.cpp
+++ b/Main.cpp
@@ -53,7 +53,7 @@ static void printUsage() {
       << "usage: oomd [OPTION]...\n\n"
          "optional arguments:\n"
          "  --help, -h                 Show this help message and exit\n"
-         "  --version                  Print version and exit\n"
+         "  --version, -v              Print version and exit\n"
          "  --config, -C CONFIG        Config file (default: /etc/oomd.json)\n"
          "  --interval, -i INTERVAL    Event loop polling interval (default: 5)\n"
          "  --cgroup-fs, -f FS         Cgroup2 filesystem mount point (default: /sys/fs/cgroup)\n"

--- a/include/Version.h.in
+++ b/include/Version.h.in
@@ -1,0 +1,1 @@
+#define GIT_VERSION "@VCS_TAG@"

--- a/include/Version.h.in
+++ b/include/Version.h.in
@@ -1,1 +1,3 @@
+#pragma once
+
 #define GIT_VERSION "@VCS_TAG@"

--- a/meson.build
+++ b/meson.build
@@ -2,7 +2,7 @@ project('oomd', 'cpp',
   version : '0.1.0',
   license : 'GPL2')
 
-cpp_args = ['-std=c++17', '-g', '-rdynamic']
+cpp_args = ['-std=c++17', '-g', '-rdynamic', '-DMESON_BUILD']
 
 # The ".." include path is necessary if one
 # does not want to build via the "build-from-github.sh" script.
@@ -14,6 +14,16 @@ inc = include_directories('''
     .
     ..
 '''.split())
+
+# Plumbing to #define a GIT_VERSION so Main.cpp can print it out
+vcs_tagger = [meson.source_root() + '/vcs_tagger.sh',
+    meson.source_root(),
+    meson.project_version()]
+version_h = vcs_tag(
+    input : 'include/Version.h.in',
+    output : 'Version.h',
+    command : vcs_tagger)
+versiondep = declare_dependency(sources : version_h)
 
 srcs = files('''
     Log.cpp
@@ -47,7 +57,8 @@ srcs = files('''
     plugins/KillPressure.cpp
 '''.split())
 
-deps = [dependency('jsoncpp'),
+deps = [versiondep,
+        dependency('jsoncpp'),
         dependency('threads')]
 
 # Optional dependencies

--- a/vcs_tagger.sh
+++ b/vcs_tagger.sh
@@ -7,5 +7,5 @@ fallback="$2"
 
 # Go into provided dir so builds started from outside the project
 # directory still generate the right tags
-cd "$dir" &>/dev/null && git describe --abbrev=4 --dirty --tags 2>/dev/null ||
+cd "$dir" &>/dev/null && git describe --abbrev=7 --dirty --tags 2>/dev/null ||
   echo "$fallback"

--- a/vcs_tagger.sh
+++ b/vcs_tagger.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -euo pipefail
+
+dir="$1"
+fallback="$2"
+
+# Go into provided dir so builds started from outside the project
+# directory still generate the right tags
+cd "$dir" &>/dev/null && git describe --abbrev=4 --dirty --tags 2>/dev/null ||
+  echo "$fallback"


### PR DESCRIPTION
This helps distros manage releases. It's also normally good practice
for open source binaries to have one.

This closes #76. 