### PR TITLE
Make memory_reclaim get cgroup names from core

### DIFF
--- a/plugins/CorePluginsTest.cpp
+++ b/plugins/CorePluginsTest.cpp
@@ -655,6 +655,9 @@ TEST(MemoryReclaim, SingleCgroupReclaimSuccess) {
   ASSERT_EQ(plugin->init(resources, std::move(args)), 0);
 
   OomdContext ctx;
+  ctx.setCgroupContext(
+      CgroupPath(args["cgroup_fs"], "cgroup1"),
+      {});
   EXPECT_EQ(plugin->run(ctx), Engine::PluginRet::CONTINUE);
 }
 
@@ -671,6 +674,12 @@ TEST(MemoryReclaim, MultiCgroupReclaimSuccess) {
   ASSERT_EQ(plugin->init(resources, std::move(args)), 0);
 
   OomdContext ctx;
+  ctx.setCgroupContext(
+      CgroupPath(args["cgroup_fs"], "cgroup1"),
+      {});
+  ctx.setCgroupContext(
+      CgroupPath(args["cgroup_fs"], "cgroup2"),
+      {});
   EXPECT_EQ(plugin->run(ctx), Engine::PluginRet::CONTINUE);
 }
 

--- a/plugins/MemoryReclaim-inl.h
+++ b/plugins/MemoryReclaim-inl.h
@@ -1,0 +1,95 @@
+/*
+ * Copyright (C) 2018-present, Facebook, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include "oomd/plugins/MemoryReclaim.h"
+
+#include "oomd/Log.h"
+#include "oomd/PluginRegistry.h"
+#include "oomd/util/Fs.h"
+#include "oomd/util/ScopeGuard.h"
+#include "oomd/util/Util.h"
+
+static constexpr auto kCgroupFs = "/sys/fs/cgroup/";
+static constexpr auto kPgscan = "pgscan";
+
+namespace Oomd {
+
+template <typename Base>
+int MemoryReclaim<Base>::init(
+    Engine::MonitoredResources& resources,
+    const Engine::PluginArgs& args) {
+  if (args.find("cgroup") != args.end()) {
+    auto cgroup_fs =
+        (args.find("cgroup_fs") != args.end() ? args.at("cgroup_fs")
+                                              : kCgroupFs);
+
+    auto cgroups = Util::split(args.at("cgroup"), ',');
+    for (const auto& c : cgroups) {
+      resources.emplace(cgroup_fs, c);
+      cgroups_.emplace(cgroup_fs, c);
+    }
+  } else {
+    OLOG << "Argument=cgroup not present";
+    return 1;
+  }
+
+  if (args.find("duration") != args.end()) {
+    duration_ = std::stoi(args.at("duration"));
+  } else {
+    OLOG << "Argument=duration not present";
+    return 1;
+  }
+
+  // Success
+  return 0;
+}
+
+template <typename Base>
+Engine::PluginRet MemoryReclaim<Base>::run(OomdContext& ctx) {
+  using std::chrono::steady_clock;
+
+  auto resolved_cgroups = ctx.reverseSort();
+  Base::removeSiblingCgroups(cgroups_, resolved_cgroups);
+
+  int64_t pgscan = 0;
+  for (const auto& cg : resolved_cgroups) {
+    auto memstat = Fs::getMemstat(cg.first.absolutePath());
+    pgscan += memstat[kPgscan];
+  }
+
+  OOMD_SCOPE_EXIT {
+    last_pgscan_ = pgscan;
+  };
+
+  const auto now = steady_clock::now();
+
+  if (pgscan > last_pgscan_) {
+    last_reclaim_at_ = now;
+  }
+
+  const auto diff =
+      std::chrono::duration_cast<std::chrono::seconds>(now - last_reclaim_at_)
+          .count();
+
+  if (diff <= duration_) {
+    return Engine::PluginRet::CONTINUE;
+  } else {
+    return Engine::PluginRet::STOP;
+  }
+}
+
+} // namespace Oomd

--- a/plugins/MemoryReclaim.cpp
+++ b/plugins/MemoryReclaim.cpp
@@ -17,81 +17,8 @@
 
 #include "oomd/plugins/MemoryReclaim.h"
 
-#include "oomd/Log.h"
 #include "oomd/PluginRegistry.h"
-#include "oomd/util/Fs.h"
-#include "oomd/util/ScopeGuard.h"
-#include "oomd/util/Util.h"
-
-static constexpr auto kCgroupFs = "/sys/fs/cgroup/";
-static constexpr auto kPgscan = "pgscan";
 
 namespace Oomd {
-
-REGISTER_PLUGIN(memory_reclaim, MemoryReclaim::create);
-
-int MemoryReclaim::init(
-    Engine::MonitoredResources& /* unused */,
-    const Engine::PluginArgs& args) {
-  if (args.find("cgroup") != args.end()) {
-    auto cgroup_fs =
-        (args.find("cgroup_fs") != args.end() ? args.at("cgroup_fs")
-                                              : kCgroupFs);
-
-    auto cgroups = Util::split(args.at("cgroup"), ',');
-    for (const auto& c : cgroups) {
-      cgroups_.emplace(cgroup_fs, c);
-    }
-  } else {
-    OLOG << "Argument=cgroup not present";
-    return 1;
-  }
-
-  if (args.find("duration") != args.end()) {
-    duration_ = std::stoi(args.at("duration"));
-  } else {
-    OLOG << "Argument=duration not present";
-    return 1;
-  }
-
-  // Success
-  return 0;
-}
-
-Engine::PluginRet MemoryReclaim::run(OomdContext& /* unused */) {
-  using std::chrono::steady_clock;
-
-  std::unordered_set<std::string> resolved_cgroups;
-  for (const auto& cgroup : cgroups_) {
-    auto resolved = Fs::resolveWildcardPath(cgroup.absolutePath());
-    resolved_cgroups.insert(resolved.begin(), resolved.end());
-  }
-
-  int64_t pgscan = 0;
-  for (const auto& abs_cgroup_path : resolved_cgroups) {
-    auto memstat = Fs::getMemstat(abs_cgroup_path);
-    pgscan += memstat[kPgscan];
-  }
-
-  OOMD_SCOPE_EXIT {
-    last_pgscan_ = pgscan;
-  };
-
-  const auto now = steady_clock::now();
-
-  if (pgscan > last_pgscan_) {
-    last_reclaim_at_ = now;
-  }
-
-  const auto diff =
-      std::chrono::duration_cast<std::chrono::seconds>(now - last_reclaim_at_)
-          .count();
-
-  if (diff <= duration_) {
-    return Engine::PluginRet::CONTINUE;
-  } else {
-    return Engine::PluginRet::STOP;
-  }
-}
-
+REGISTER_PLUGIN(memory_reclaim, MemoryReclaim<>::create);
 } // namespace Oomd

--- a/plugins/MemoryReclaim.h
+++ b/plugins/MemoryReclaim.h
@@ -20,11 +20,12 @@
 #include <chrono>
 #include <unordered_set>
 
-#include "oomd/engine/BasePlugin.h"
+#include "oomd/plugins/BaseKillPlugin.h"
 
 namespace Oomd {
 
-class MemoryReclaim : public Oomd::Engine::BasePlugin {
+template <typename Base = BaseKillPlugin>
+class MemoryReclaim : public Base {
  public:
   int init(
       Engine::MonitoredResources& /* unused */,
@@ -47,3 +48,5 @@ class MemoryReclaim : public Oomd::Engine::BasePlugin {
 };
 
 } // namespace Oomd
+
+#include "oomd/plugins/MemoryReclaim-inl.h"


### PR DESCRIPTION
memory_reclaim was manually resolving wildcarded cgroups without
checking if resolved paths are directories or control files. This caused
weird errors like in issue #78.

This patch makes memory_reclaim pull data from core which already has
this error checking.

Note: it's somewhat suboptimal we're inheriting BaseKillPlugin b/c this
is not a killing plugin. At some point someone should pull out
removeSilbingCgroups to a different class.