### PR TITLE
Print more logs on test failure

### DIFF
--- a/oomd/build-from-github.sh
+++ b/oomd/build-from-github.sh
@@ -16,4 +16,6 @@ ln -f -s $(which g++-8) $(which g++)
 meson $OUTDIR
 cd $OUTDIR
 ninja
+set +e
 meson test --print-errorlogs
+cat meson-logs/testlog.txt


### PR DESCRIPTION
This helps with debugging CI test failures.