### PR TITLE
Skip root host monitor test if cgroup2 not running

### DIFF
--- a/oomd/OomdTest.cpp
+++ b/oomd/OomdTest.cpp
@@ -161,7 +161,14 @@ TEST_F(OomdTest, CalculateProtectionOverage) {
 TEST_F(OomdTest, MonitorRootHost) {
   std::string cgroup2fs_mntpt = Fs::getCgroup2MountPoint();
   if (cgroup2fs_mntpt.empty()) {
-    FAIL() << "Host not running cgroup2";
+#ifdef MESON_BUILD
+    // GTEST_SKIP() is in gtest 1.9.x (note: starting at 1.9.x,
+    // gtest is living at master) and it's unlikely that it will
+    // ever get packaged.
+    return;
+#else
+    GTEST_SKIP() << "Host not running cgroup2";
+#endif
   }
 
   std::unordered_set<CgroupPath> cgroups;


### PR DESCRIPTION
If we're not using cgroup2 we should bail on this test since it relies
on new system features.