### PR TITLE
refactor fixture utils for test

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -50,6 +50,8 @@ srcs = files('''
     src/oomd/plugins/KillPressure.cpp
 '''.split())
 
+fixture_srcs = files(['src/oomd/util/Fixture.cpp'])
+
 deps = [versiondep,
         dependency('jsoncpp'),
         dependency('threads')]
@@ -71,6 +73,12 @@ oomd_lib = static_library('oomd',
                           cpp_args : cpp_args,
                           install : false,
                           dependencies : deps)
+oomd_fixture_lib = static_library('oomd_fixture',
+                                  fixture_srcs,
+                                  include_directories : inc,
+                                  cpp_args : cpp_args,
+                                  dependencies : deps,
+                                  link_with : oomd_lib)
 executable('oomd_bin',
            files('src/oomd/Main.cpp'),
            include_directories : inc,
@@ -86,7 +94,8 @@ executable('oomd_bin',
 core_tests = [
   ['config',   files('src/oomd/config/JsonConfigParserTest.cpp')],
   ['oomd',     files('src/oomd/OomdTest.cpp')],
-  ['util',     files('src/oomd/util/FsTest.cpp',
+  ['util',     files('src/oomd/util/FixtureTest.cpp',
+                     'src/oomd/util/FsTest.cpp',
                      'src/oomd/util/ScopeGuardTest.cpp',
                      'src/oomd/util/UtilTest.cpp')],
   ['context',  files('src/oomd/OomdContextTest.cpp')],
@@ -120,7 +129,7 @@ if gtest_dep.found() and gmock_dep.found()
             include_directories : inc,
             cpp_args : cpp_args,
             dependencies : deps,
-            link_whole : oomd_lib)
+            link_whole : [oomd_lib, oomd_fixture_lib])
         test(executable_name_suffix,
              test_executable,
              workdir : meson.source_root() + '/src')

--- a/src/oomd/util/Fixture.cpp
+++ b/src/oomd/util/Fixture.cpp
@@ -1,0 +1,160 @@
+/*
+ * Copyright (C) 2018-present, Facebook, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include <fcntl.h>
+#include <ftw.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+
+#include <array>
+#include <cstdlib>
+#include <stdexcept>
+
+#include "oomd/util/Fixture.h"
+#include "oomd/util/Util.h"
+
+constexpr auto kFixturesDirTemplate = "__oomd_fixtures_XXXXXX";
+
+namespace Oomd {
+
+// static
+Fixture::DirEntryPair Fixture::makeFile(
+    const std::string& name,
+    const std::string& content) {
+  return {name,
+          DirEntry([content](const std::string& path, const std::string& name) {
+            writeChecked(path + "/" + name, content);
+          })};
+}
+
+// static
+Fixture::DirEntryPair Fixture::makeDir(
+    const std::string& name,
+    std::unordered_map<std::string, DirEntry> entries) {
+  return {name,
+          DirEntry([entries](const std::string& path, const std::string& name) {
+            mkdirsChecked(name, path);
+            const auto newPath = path + "/" + name;
+            for (const auto& kv : entries) {
+              kv.second.materialize(newPath, kv.first);
+            }
+          })};
+}
+
+const char* getTempDir() {
+  if (std::getenv("TMPDIR") != nullptr) {
+    return std::getenv("TMPDIR");
+  } else if (std::getenv("TMP") != nullptr) {
+    return std::getenv("TMP");
+  } else if (std::getenv("TEMP") != nullptr) {
+    return std::getenv("TEMP");
+  } else if (std::getenv("TEMPDIR") != nullptr) {
+    return std::getenv("TEMPDIR");
+  } else {
+    return "/tmp";
+  }
+}
+
+// static
+std::string Fixture::mkdtempChecked() {
+  std::array<char, 1024> temp;
+  ::snprintf(
+      temp.data(), temp.size(), "%s/%s", getTempDir(), kFixturesDirTemplate);
+
+  if (::mkdtemp(temp.data()) == nullptr) {
+    std::array<char, 1024> buf;
+    buf[0] = '\0';
+    throw std::runtime_error(
+        std::string(temp.data()) +
+        ": mkdtemp failed: " + ::strerror_r(errno, buf.data(), buf.size()));
+  }
+  return temp.data();
+}
+
+// static
+void Fixture::mkdirsChecked(
+    const std::string& path,
+    const std::string& prefix) {
+  auto dirs = Util::split(path, '/');
+  std::string prefix_path;
+  // two slashes after each component
+  prefix_path.reserve(path.size() + prefix.size() + 2);
+  prefix_path += prefix;
+  if (prefix_path != "") {
+    prefix_path += "/";
+  }
+  for (const auto& dir : dirs) {
+    if (dir == "") {
+      continue;
+    }
+    prefix_path += dir + "/";
+    if (::mkdir(prefix_path.c_str(), 0777) == -1 && errno != EEXIST) {
+      std::array<char, 1024> buf;
+      buf[0] = '\0';
+      throw std::runtime_error(
+          prefix_path +
+          ": mkdir failed: " + ::strerror_r(errno, buf.data(), buf.size()));
+    }
+  }
+}
+
+// static
+void Fixture::writeChecked(
+    const std::string& path,
+    const std::string& content) {
+  std::array<char, 1024> buf;
+  buf[0] = '\0';
+  auto fd = ::open(path.c_str(), O_CREAT | O_WRONLY | O_TRUNC, 0666);
+  if (fd < 0) {
+    throw std::runtime_error(
+        path + ": open failed: " + ::strerror_r(errno, buf.data(), buf.size()));
+  }
+  auto ret = Util::writeFull(fd, content.c_str(), content.size());
+  ::close(fd);
+  if (ret < 0) {
+    throw std::runtime_error(
+        path +
+        ": write failed: " + ::strerror_r(errno, buf.data(), buf.size()));
+  }
+  if ((size_t)ret != content.size()) {
+    throw std::runtime_error(
+        path + ": write failed: not all bytes are written");
+  }
+}
+
+int rm(const char* path, const struct stat*, int, struct FTW*) {
+  return ::remove(path);
+}
+
+// static
+void Fixture::rmrChecked(const std::string& path) {
+  std::array<char, 1024> buf;
+  buf[0] = '\0';
+  if (::nftw(path.c_str(), rm, 10, FTW_DEPTH | FTW_PHYS) == -1) {
+    switch (errno) {
+      case ENOENT:
+        return;
+      default:
+        throw std::runtime_error(
+            path +
+            ": remove failed: " + ::strerror_r(errno, buf.data(), buf.size()));
+    }
+  }
+}
+
+} // namespace Oomd

--- a/src/oomd/util/Fixture.h
+++ b/src/oomd/util/Fixture.h
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2018-present, Facebook, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#pragma once
+
+#include <functional>
+#include <initializer_list>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+namespace Oomd {
+
+// Fixture is a utility class for unit tests to encode their fixture files and
+// materialize them in run time in some temporary directory.
+class Fixture {
+ public:
+  typedef std::function<void(const std::string& path, const std::string& name)>
+      materializeFunc;
+
+  // Dirent to be materialized into a file or directory
+  class DirEntry {
+   public:
+    explicit DirEntry(materializeFunc materialize)
+        : materialize_(materialize) {}
+    void materialize(const std::string& path, const std::string& name) const {
+      materialize_(path, name);
+    }
+
+   private:
+    const materializeFunc materialize_;
+  };
+
+  // Helper functions to create different named DirEntries so that we can
+  // represent a directory tree with initializer_list in a single statement.
+  typedef std::pair<const std::string, DirEntry> DirEntryPair;
+  static DirEntryPair makeFile(
+      const std::string& name,
+      const std::string& content = "");
+  static DirEntryPair makeDir(
+      const std::string& name,
+      std::unordered_map<std::string, DirEntry> entries = {});
+
+  // utility functions that interact with file system
+  static std::string mkdtempChecked();
+  static void mkdirsChecked(
+      const std::string& path,
+      const std::string& prefix = "");
+  static void writeChecked(const std::string& path, const std::string& content);
+  static void rmrChecked(const std::string& path);
+};
+} // namespace Oomd

--- a/src/oomd/util/FixtureTest.cpp
+++ b/src/oomd/util/FixtureTest.cpp
@@ -1,0 +1,183 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+#include <dirent.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <gtest/gtest.h>
+#include <stdio.h>
+
+#include <string>
+#include <unordered_set>
+#include <vector>
+
+#include <oomd/util/Fixture.h>
+#include <oomd/util/Util.h>
+
+using namespace Oomd;
+using namespace testing;
+
+class FixtureTest : public ::testing::Test {
+ protected:
+  // remove all temp directories
+  void TearDown() override {
+    DIR* dir;
+    std::string failureMsg = "";
+    for (const auto& tempDir : tempDirs_) {
+      dir = ::opendir(tempDir.c_str());
+      if (dir != nullptr) {
+        ::closedir(dir);
+        // call `rm -r '$tempDir'` to remove recursively
+        const auto& cmd = "rm -r '" + tempDir + "'";
+        auto stream = ::popen(cmd.c_str(), "r");
+        if (stream != nullptr) {
+          ::pclose(stream);
+        }
+        dir = ::opendir(tempDir.c_str());
+        if (dir != nullptr || errno != ENOENT) {
+          failureMsg += " " + tempDir;
+        }
+      }
+    }
+    if (failureMsg != "") {
+      FAIL() << "remove failed:" + failureMsg;
+    }
+  }
+
+  std::unordered_set<std::string> tempDirs_;
+};
+
+TEST_F(FixtureTest, TestMkdtempChecked) {
+  DIR* dir;
+  std::string tempDir;
+
+  for (int i = 0; i < 100; i++) {
+    EXPECT_NO_THROW(tempDir = Fixture::mkdtempChecked());
+    // directory exists
+    EXPECT_TRUE((dir = ::opendir(tempDir.c_str())) && ::closedir(dir) == 0);
+    // directory not already seen
+    EXPECT_TRUE(tempDirs_.find(tempDir) == tempDirs_.end());
+    tempDirs_.insert(tempDir);
+  }
+}
+
+TEST_F(FixtureTest, TestMkdirsChecked) {
+  DIR* dir;
+  std::string tempDir;
+  std::string path;
+
+  EXPECT_NO_THROW(tempDir = Fixture::mkdtempChecked());
+  tempDirs_.insert(tempDir);
+
+  // nothing should happen
+  EXPECT_NO_THROW(Fixture::mkdirsChecked(tempDir));
+
+  // should ignore repeated slashes
+  EXPECT_NO_THROW(Fixture::mkdirsChecked("A//B///C/", tempDir));
+  path = tempDir + "/A/B/C";
+  EXPECT_TRUE((dir = ::opendir(path.c_str())) && ::closedir(dir) == 0);
+
+  // should create D without touching A
+  EXPECT_NO_THROW(Fixture::mkdirsChecked("A/D", tempDir));
+  path = tempDir + "/A/B/C";
+  EXPECT_TRUE((dir = ::opendir(path.c_str())) && ::closedir(dir) == 0);
+  path = tempDir + "/A/D";
+  EXPECT_TRUE((dir = ::opendir(path.c_str())) && ::closedir(dir) == 0);
+}
+
+TEST_F(FixtureTest, TestWriteChecked) {
+  std::vector<char> buf(1024);
+  std::string tempDir;
+
+  EXPECT_NO_THROW(tempDir = Fixture::mkdtempChecked());
+  tempDirs_.insert(tempDir);
+  const auto filepath = tempDir + "/writetest.txt";
+  const std::string content = "Hello, Facebook!\nHello, world!\n";
+  const std::string newContent = "Bye, Facebook!\nHello again, world!\n";
+
+  // create and write
+  EXPECT_NO_THROW(Fixture::writeChecked(filepath, content));
+  int fd = ::open(filepath.c_str(), O_RDONLY);
+  EXPECT_GE(fd, 0);
+  int bytes_read = Util::readFull(fd, buf.data(), content.length());
+  ::close(fd);
+  EXPECT_EQ(bytes_read, content.length());
+  EXPECT_EQ(std::string(buf.data(), content.length()), content);
+
+  // overwrite
+  EXPECT_NO_THROW(Fixture::writeChecked(filepath, newContent));
+  fd = ::open(filepath.c_str(), O_RDONLY);
+  EXPECT_GE(fd, 0);
+  bytes_read = Util::readFull(fd, buf.data(), newContent.length());
+  ::close(fd);
+  EXPECT_EQ(bytes_read, newContent.length());
+  EXPECT_EQ(std::string(buf.data(), newContent.length()), newContent);
+}
+
+TEST_F(FixtureTest, TestRmrChecked) {
+  DIR* dir;
+  std::string tempDir;
+
+  EXPECT_NO_THROW({
+    // create directory tree
+    tempDir = Fixture::mkdtempChecked();
+    tempDirs_.insert(tempDir);
+    Fixture::mkdirsChecked("A/B/C", tempDir);
+    Fixture::mkdirsChecked("D/E", tempDir);
+    Fixture::writeChecked(tempDir + "/file1", "file1 content");
+    Fixture::writeChecked(tempDir + "/A/file2", "file2 content");
+    Fixture::writeChecked(tempDir + "/D/E/file3", "file3 content");
+    Fixture::rmrChecked(tempDir);
+  });
+
+  tempDirs_.erase(tempDir);
+  // check file does not exist
+  dir = ::opendir(tempDir.c_str());
+  if (dir != nullptr) {
+    ::closedir(dir);
+    FAIL() << "Failed to remove tempDir: " + tempDir;
+  } else {
+    EXPECT_TRUE(errno == ENOENT);
+  }
+}
+
+bool verifyFile(const std::string& filepath, const std::string& content) {
+  int fd = ::open(filepath.c_str(), O_RDONLY);
+  if (fd < 0) {
+    return false;
+  }
+  std::vector<char> buf(content.size());
+  ssize_t count = Util::readFull(fd, buf.data(), content.size());
+  ::close(fd);
+  return std::string(buf.data(), count) == content;
+}
+
+TEST_F(FixtureTest, TestMaterialize) {
+  DIR* dir;
+  std::string tempDir;
+
+  EXPECT_NO_THROW(tempDir = Fixture::mkdtempChecked());
+  tempDirs_.insert(tempDir);
+  const auto fixture = Fixture::makeDir(
+      "root",
+      {Fixture::makeDir(
+           "A",
+           {Fixture::makeDir("B", {Fixture::makeDir("C")}),
+            Fixture::makeFile("file2", "file2 content")}),
+
+       Fixture::makeDir(
+           "D",
+           {Fixture::makeDir(
+               "E", {Fixture::makeFile("file3", "file3 content")})}),
+       Fixture::makeFile("file1", "file1 content")});
+  EXPECT_NO_THROW(fixture.second.materialize(tempDir, fixture.first));
+
+  auto root = tempDir + "/" + "root";
+  auto path = root + "/A/B/C";
+  EXPECT_TRUE((dir = ::opendir(path.c_str())) && ::closedir(dir) == 0);
+  path = root + "/A/file2";
+  EXPECT_TRUE(verifyFile(path, "file2 content"));
+  path = root + "/D/E/file3";
+  EXPECT_TRUE(verifyFile(path, "file3 content"));
+  path = root + "/file1";
+  EXPECT_TRUE(verifyFile(path, "file1 content"));
+}


### PR DESCRIPTION
Summary:
Refactor fixture utils from FsTest into a class so other test suites can use.

Create data structure classes `DirEntry` to encode the fixture directory tree. It is designed that we can use a few deeply nested (tree-like) initializer_list to construct a complex fixture structure, but still with OK readability. The goal is to generate all fixtures using this infrastructure in run time.

Differential Revision: D17001894

