### PR TITLE
Minor meson.build fixes

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,9 +1,9 @@
 project('oomd', 'cpp',
   version : '0.1.0',
   license : 'GPL2',
-  default_options : ['stdsplit=false'])
+  default_options : ['stdsplit=false', 'cpp_std=c++17'])
 
-cpp_args = ['-std=c++17', '-g', '-rdynamic', '-DMESON_BUILD']
+cpp_args = ['-DMESON_BUILD']
 
 inc = include_directories('''
     oomd/include


### PR DESCRIPTION
The clang build is telling us -rdynamic isn't used. This seems correct
since we're no longer creating any dynamic libraries.

Also remove -g as that's the default anyways.

Also use more meson-ic features.

This closes #54 .