### PR TITLE
generate FsTest fixtures

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -50,6 +50,8 @@ srcs = files('''
     src/oomd/plugins/KillPressure.cpp
 '''.split())
 
+fixture_srcs = files(['src/oomd/util/Fixture.cpp'])
+
 deps = [versiondep,
         dependency('jsoncpp'),
         dependency('threads')]
@@ -71,6 +73,12 @@ oomd_lib = static_library('oomd',
                           cpp_args : cpp_args,
                           install : false,
                           dependencies : deps)
+oomd_fixture_lib = static_library('oomd_fixture',
+                                  fixture_srcs,
+                                  include_directories : inc,
+                                  cpp_args : cpp_args,
+                                  dependencies : deps,
+                                  link_with : oomd_lib)
 executable('oomd_bin',
            files('src/oomd/Main.cpp'),
            include_directories : inc,
@@ -86,7 +94,8 @@ executable('oomd_bin',
 core_tests = [
   ['config',   files('src/oomd/config/JsonConfigParserTest.cpp')],
   ['oomd',     files('src/oomd/OomdTest.cpp')],
-  ['util',     files('src/oomd/util/FsTest.cpp',
+  ['util',     files('src/oomd/util/FixtureTest.cpp',
+                     'src/oomd/util/FsTest.cpp',
                      'src/oomd/util/ScopeGuardTest.cpp',
                      'src/oomd/util/UtilTest.cpp')],
   ['context',  files('src/oomd/OomdContextTest.cpp')],
@@ -120,7 +129,7 @@ if gtest_dep.found() and gmock_dep.found()
             include_directories : inc,
             cpp_args : cpp_args,
             dependencies : deps,
-            link_whole : oomd_lib)
+            link_whole : [oomd_lib, oomd_fixture_lib])
         test(executable_name_suffix,
              test_executable,
              workdir : meson.source_root() + '/src')

--- a/meson.build
+++ b/meson.build
@@ -50,7 +50,10 @@ srcs = files('''
     src/oomd/plugins/KillPressure.cpp
 '''.split())
 
-fixture_srcs = files(['src/oomd/util/Fixture.cpp'])
+fixture_srcs = files('''
+    src/oomd/fixtures/FsFixture.cpp
+    src/oomd/util/Fixture.cpp
+'''.split())
 
 deps = [versiondep,
         dependency('jsoncpp'),

--- a/src/oomd/fixtures/FsFixture.cpp
+++ b/src/oomd/fixtures/FsFixture.cpp
@@ -1,0 +1,306 @@
+/*
+ * Copyright (C) 2018-present, Facebook, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include "oomd/fixtures/FsFixture.h"
+
+namespace Oomd {
+
+constexpr auto kDataMeminfo = R"(MemTotal:       58616708 kB
+MemFree:         2955848 kB
+MemAvailable:   49878948 kB
+Buffers:         4970160 kB
+Cached:         35172508 kB
+SwapCached:            0 kB
+Active:         27822776 kB
+Inactive:       19032824 kB
+Active(anon):    4024064 kB
+Inactive(anon):  2822876 kB
+Active(file):   23798712 kB
+Inactive(file): 16209948 kB
+Unevictable:       11684 kB
+Mlocked:           11668 kB
+SwapTotal:       2097148 kB
+SwapFree:        1097041 kB
+Dirty:             24576 kB
+Writeback:             0 kB
+AnonPages:       6725380 kB
+Mapped:           657992 kB
+Shmem:            130124 kB
+Slab:            8238080 kB
+SReclaimable:    7334616 kB
+SUnreclaim:       903464 kB
+KernelStack:       45984 kB
+PageTables:        75756 kB
+NFS_Unstable:          0 kB
+Bounce:                0 kB
+WritebackTmp:          0 kB
+CommitLimit:    31405500 kB
+Committed_AS:   21265672 kB
+VmallocTotal:   34359738367 kB
+VmallocUsed:           0 kB
+VmallocChunk:          0 kB
+HardwareCorrupted:     0 kB
+AnonHugePages:     71680 kB
+ShmemHugePages:        0 kB
+ShmemPmdMapped:        0 kB
+CmaTotal:              0 kB
+CmaFree:               0 kB
+HugePages_Total:       0
+HugePages_Free:        0
+HugePages_Rsvd:        0
+HugePages_Surp:        0
+Hugepagesize:       2048 kB
+Hugetlb:               0 kB
+DirectMap4k:     4544368 kB
+DirectMap2M:    53127168 kB
+DirectMap1G:     4194304 kB
+)";
+
+constexpr auto kDataMounts =
+    R"(sysfs /sys sysfs rw,seclabel,nosuid,nodev,noexec,relatime 0 0
+proc /proc proc rw,nosuid,nodev,noexec,relatime 0 0
+devtmpfs /dev devtmpfs rw,seclabel,nosuid,size=58710812k,nr_inodes=14677703,mode=755 0 0
+securityfs /sys/kernel/security securityfs rw,nosuid,nodev,noexec,relatime 0 0
+tmpfs /dev/shm tmpfs rw,seclabel,nosuid,nodev 0 0
+devpts /dev/pts devpts rw,seclabel,nosuid,noexec,relatime,gid=5,mode=620,ptmxmode=000 0 0
+tmpfs /run tmpfs rw,seclabel,nosuid,nodev,mode=755 0 0
+cgroup2 /sys/fs/cgroup cgroup2 rw,nosuid,nodev,noexec,relatime,nsdelegate 0 0
+pstore /sys/fs/pstore pstore rw,seclabel,nosuid,nodev,noexec,relatime 0 0
+bpf /sys/fs/bpf bpf rw,relatime,mode=700 0 0
+configfs /sys/kernel/config configfs rw,relatime 0 0
+/dev/vda3 / btrfs rw,seclabel,relatime,compress-force=zstd,discard,space_cache,subvolid=5,subvol=/ 0 0
+selinuxfs /sys/fs/selinux selinuxfs rw,relatime 0 0
+systemd-1 /proc/sys/fs/binfmt_misc autofs rw,relatime,fd=26,pgrp=1,timeout=0,minproto=5,maxproto=5,direct 0 0
+hugetlbfs /dev/hugepages hugetlbfs rw,seclabel,relatime,pagesize=2M 0 0
+debugfs /sys/kernel/debug debugfs rw,seclabel,relatime,mode=755 0 0
+mqueue /dev/mqueue mqueue rw,seclabel,relatime 0 0
+sunrpc /var/lib/nfs/rpc_pipefs rpc_pipefs rw,relatime 0 0
+nfsd /proc/fs/nfsd nfsd rw,relatime 0 0
+fusectl /sys/fs/fuse/connections fusectl rw,relatime 0 0
+/dev/vda1 /boot ext4 rw,seclabel,relatime,data=ordered 0 0
+none-tw-channel /run/facebook/tw_logging_channel tmpfs rw,seclabel,relatime,size=10240k,nr_inodes=4096 0 0
+tracefs /sys/kernel/debug/tracing tracefs rw,seclabel,relatime 0 0
+/etc/auto.home.override /home autofs rw,relatime,fd=5,pgrp=2182594,timeout=600,minproto=5,maxproto=5,indirect 0 0
+binfmt_misc /proc/sys/fs/binfmt_misc binfmt_misc rw,relatime 0 0
+tmpfs /run/user/30015 tmpfs rw,seclabel,nosuid,nodev,relatime,size=11744436k,mode=700,uid=30015,gid=30015 0 0
+tmpfs /run/user/0 tmpfs rw,seclabel,nosuid,nodev,relatime,size=11744436k,mode=700 0 0
+tmpfs /run/user/180401 tmpfs rw,seclabel,nosuid,nodev,relatime,size=11744436k,mode=700,uid=180401,gid=100 0 0
+)";
+
+constexpr auto kDataCgMemStat = R"(anon 1294168064
+file 3870687232
+kernel_stack 7225344
+slab 296456192
+sock 1228800
+shmem 135168
+file_mapped 199778304
+file_dirty 405504
+file_writeback 811008
+inactive_anon 296529920
+active_anon 997982208
+inactive_file 1284907008
+active_file 2586988544
+unevictable 28672
+slab_reclaimable 262471680
+slab_unreclaimable 33984512
+pgfault 734452455
+pgmajfault 4627590
+pgrefill 243154
+pgscan 787288
+pgsteal 770913
+pgactivate 13992
+pgdeactivate 233504
+pglazyfree 0
+pglazyfreed 0
+workingset_refault 510510
+workingset_activate 25608
+workingset_restore 3927
+workingset_nodereclaim 0
+)";
+
+constexpr auto kDataVmstat = R"(first_key 12345
+second_key 678910
+thirdkey 999999
+)";
+
+namespace {
+
+using F = Fixture;
+
+const auto kEntCgroup = F::makeDir(
+    "cgroup",
+    {F::makeDir(
+        "system.slice",
+        {
+            F::makeDir(
+                "service1.service",
+                {F::makeFile(
+                    "cgroup.procs",
+                    "456\n"
+                    "789\n")}),
+            F::makeDir(
+                "service2.service",
+                {F::makeFile(
+                    "memory.pressure",
+                    "aggr 128544748770\n"
+                    "some 1.11 2.22 3.33\n"
+                    "full 4.44 5.55 6.66\n")}),
+            F::makeDir(
+                "service3.service",
+                {F::makeFile(
+                    "memory.pressure",
+                    "aggr 128544748770\n"
+                    "some 1.11 2.22 3.33\n"
+                    "full 4.44 5.55 6.66\n"
+                    "0 0 0\n"
+                    "0 0 0\n"
+                    "0 0 0\n"
+                    "0 0 0\n")}),
+            F::makeDir(
+                "slice1.slice",
+                {F::makeDir(
+                     "service1.service",
+                     {F::makeFile(
+                         "cgroup.procs",
+                         "456\n"
+                         "789\n")}),
+                 F::makeDir(
+                     "service2.service",
+                     {F::makeFile(
+                         "cgroup.procs",
+                         "12\n"
+                         "34\n")})}),
+            F::makeFile("cgroup.controllers", "cpu io memory pids\n"),
+            F::makeFile("cgroup.procs", "123\n"),
+            F::makeFile(
+                "io.pressure",
+                "some avg10=1.12 avg60=2.23 avg300=3.34 total=134829384401\n"
+                "full avg10=4.45 avg60=5.56 avg300=6.67 total=128544748771\n"),
+            F::makeFile(
+                "io.stat",
+                "1:10 rbytes=1111111 wbytes=2222222 rios=33 wios=44 dbytes=5555555555 dios=6\n"
+                "1:11 rbytes=2222222 wbytes=3333333 rios=44 wios=55 dbytes=6666666666 dios=7\n"),
+            F::makeFile("memory.current", "987654321\n"),
+            F::makeFile("memory.high", "1000\n"),
+            F::makeFile("memory.high.tmp", "2000 20000\n"),
+            F::makeFile("memory.low", "333333\n"),
+            F::makeFile("memory.min", "666\n"),
+            F::makeFile(
+                "memory.pressure",
+                "some avg10=1.11 avg60=2.22 avg300=3.33 total=134829384400\n"
+                "full avg10=4.44 avg60=5.55 avg300=6.66 total=128544748770\n"),
+            F::makeFile("memory.stat", kDataCgMemStat),
+            F::makeFile("memory.swap.current", "321321\n"),
+        })});
+
+const auto kEntFsData = F::makeDir(
+    "fs_data",
+    {
+        F::makeDir(
+            "dir1",
+            {
+                F::makeFile(
+                    "stuff",
+                    "hello world\n"
+                    "my good man\n"
+                    "\n"
+                    "1\n"),
+            }),
+        F::makeDir("dir2", {F::makeFile("empty")}),
+        F::makeDir("dir3", {F::makeFile("empty")}),
+        F::makeDir(
+            "wildcard/this/path",
+            {
+                F::makeDir("is/going/to/be/long", {F::makeFile("file")}),
+                F::makeDir("isNOT/going/to/be/long", {F::makeFile("file")}),
+                F::makeDir("WAH/going/to/be/long", {F::makeFile("file")}),
+            }),
+        F::makeFile("file1"),
+        F::makeFile("file2"),
+        F::makeFile("file3"),
+        F::makeFile("file4"),
+    });
+
+const auto kEntProc = F::makeDir(
+    "proc",
+    {
+        F::makeFile("meminfo", kDataMeminfo),
+        F::makeFile("mounts", kDataMounts),
+        F::makeFile("vmstat", kDataVmstat),
+    });
+
+const auto kEntSysDevBlock = F::makeDir(
+    "sys_dev_block",
+    {
+        F::makeDir(
+            "1:0",
+            {F::makeDir("queue", {F::makeFile("rotational", "0\n")})}),
+        F::makeDir(
+            "1:1",
+            {F::makeDir("queue", {F::makeFile("rotational", "1\n")})}),
+        F::makeDir(
+            "1:2",
+            {F::makeDir("queue", {F::makeFile("rotational", "\n")})}),
+    });
+
+const auto kEntFsFixture = F::makeDir(
+    "fs_test",
+    {
+        kEntCgroup,
+        kEntFsData,
+        kEntProc,
+        kEntSysDevBlock,
+    });
+
+} // namespace
+
+constexpr auto kCgroupDataDir = "fs_test/cgroup/system.slice";
+constexpr auto kFsDataDir = "fs_test/fs_data";
+constexpr auto kFsVmstatFile = "fs_test/proc/vmstat";
+constexpr auto kFsMeminfoFile = "fs_test/proc/meminfo";
+constexpr auto kFsMountsFile = "fs_test/proc/mounts";
+constexpr auto kFsDeviceDir = "fs_test/sys_dev_block";
+
+void FsFixture::materialize() {
+  tempFixtureDir_ = F::mkdtempChecked();
+  kEntFsFixture.second.materialize(tempFixtureDir_, kEntFsFixture.first);
+}
+
+void FsFixture::teardown() {
+  F::rmrChecked(tempFixtureDir_);
+  tempFixtureDir_ = "";
+}
+
+std::string FsFixture::cgroupDataDir() {
+  return tempFixtureDir_ + "/" + kCgroupDataDir;
+}
+std::string FsFixture::fsDataDir() {
+  return tempFixtureDir_ + "/" + kFsDataDir;
+}
+std::string FsFixture::fsVmstatFile() {
+  return tempFixtureDir_ + "/" + kFsVmstatFile;
+}
+std::string FsFixture::fsMeminfoFile() {
+  return tempFixtureDir_ + "/" + kFsMeminfoFile;
+}
+std::string FsFixture::fsMountsFile() {
+  return tempFixtureDir_ + "/" + kFsMountsFile;
+}
+std::string FsFixture::fsDeviceDir() {
+  return tempFixtureDir_ + "/" + kFsDeviceDir;
+}
+} // namespace Oomd

--- a/src/oomd/fixtures/FsFixture.h
+++ b/src/oomd/fixtures/FsFixture.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2018-present, Facebook, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#pragma once
+
+#include "oomd/util/Fixture.h"
+
+namespace Oomd {
+
+class FsFixture {
+ public:
+  void materialize();
+  void teardown();
+  std::string cgroupDataDir();
+  std::string fsDataDir();
+  std::string fsVmstatFile();
+  std::string fsMeminfoFile();
+  std::string fsMountsFile();
+  std::string fsDeviceDir();
+
+ private:
+  std::string tempFixtureDir_{};
+};
+
+} // namespace Oomd

--- a/src/oomd/util/Fixture.cpp
+++ b/src/oomd/util/Fixture.cpp
@@ -1,0 +1,160 @@
+/*
+ * Copyright (C) 2018-present, Facebook, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include <fcntl.h>
+#include <ftw.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+
+#include <array>
+#include <cstdlib>
+#include <stdexcept>
+
+#include "oomd/util/Fixture.h"
+#include "oomd/util/Util.h"
+
+constexpr auto kFixturesDirTemplate = "__oomd_fixtures_XXXXXX";
+
+namespace Oomd {
+
+// static
+Fixture::DirEntryPair Fixture::makeFile(
+    const std::string& name,
+    const std::string& content) {
+  return {name,
+          DirEntry([content](const std::string& path, const std::string& name) {
+            writeChecked(path + "/" + name, content);
+          })};
+}
+
+// static
+Fixture::DirEntryPair Fixture::makeDir(
+    const std::string& name,
+    std::unordered_map<std::string, DirEntry> entries) {
+  return {name,
+          DirEntry([entries](const std::string& path, const std::string& name) {
+            mkdirsChecked(name, path);
+            const auto newPath = path + "/" + name;
+            for (const auto& kv : entries) {
+              kv.second.materialize(newPath, kv.first);
+            }
+          })};
+}
+
+const char* getTempDir() {
+  if (std::getenv("TMPDIR") != nullptr) {
+    return std::getenv("TMPDIR");
+  } else if (std::getenv("TMP") != nullptr) {
+    return std::getenv("TMP");
+  } else if (std::getenv("TEMP") != nullptr) {
+    return std::getenv("TEMP");
+  } else if (std::getenv("TEMPDIR") != nullptr) {
+    return std::getenv("TEMPDIR");
+  } else {
+    return "/tmp";
+  }
+}
+
+// static
+std::string Fixture::mkdtempChecked() {
+  std::array<char, 1024> temp;
+  ::snprintf(
+      temp.data(), temp.size(), "%s/%s", getTempDir(), kFixturesDirTemplate);
+
+  if (::mkdtemp(temp.data()) == nullptr) {
+    std::array<char, 1024> buf;
+    buf[0] = '\0';
+    throw std::runtime_error(
+        std::string(temp.data()) +
+        ": mkdtemp failed: " + ::strerror_r(errno, buf.data(), buf.size()));
+  }
+  return temp.data();
+}
+
+// static
+void Fixture::mkdirsChecked(
+    const std::string& path,
+    const std::string& prefix) {
+  auto dirs = Util::split(path, '/');
+  std::string prefix_path;
+  // two slashes after each component
+  prefix_path.reserve(path.size() + prefix.size() + 2);
+  prefix_path += prefix;
+  if (prefix_path != "") {
+    prefix_path += "/";
+  }
+  for (const auto& dir : dirs) {
+    if (dir == "") {
+      continue;
+    }
+    prefix_path += dir + "/";
+    if (::mkdir(prefix_path.c_str(), 0777) == -1 && errno != EEXIST) {
+      std::array<char, 1024> buf;
+      buf[0] = '\0';
+      throw std::runtime_error(
+          prefix_path +
+          ": mkdir failed: " + ::strerror_r(errno, buf.data(), buf.size()));
+    }
+  }
+}
+
+// static
+void Fixture::writeChecked(
+    const std::string& path,
+    const std::string& content) {
+  std::array<char, 1024> buf;
+  buf[0] = '\0';
+  auto fd = ::open(path.c_str(), O_CREAT | O_WRONLY | O_TRUNC, 0666);
+  if (fd < 0) {
+    throw std::runtime_error(
+        path + ": open failed: " + ::strerror_r(errno, buf.data(), buf.size()));
+  }
+  auto ret = Util::writeFull(fd, content.c_str(), content.size());
+  ::close(fd);
+  if (ret < 0) {
+    throw std::runtime_error(
+        path +
+        ": write failed: " + ::strerror_r(errno, buf.data(), buf.size()));
+  }
+  if ((size_t)ret != content.size()) {
+    throw std::runtime_error(
+        path + ": write failed: not all bytes are written");
+  }
+}
+
+int rm(const char* path, const struct stat*, int, struct FTW*) {
+  return ::remove(path);
+}
+
+// static
+void Fixture::rmrChecked(const std::string& path) {
+  std::array<char, 1024> buf;
+  buf[0] = '\0';
+  if (::nftw(path.c_str(), rm, 10, FTW_DEPTH | FTW_PHYS) == -1) {
+    switch (errno) {
+      case ENOENT:
+        return;
+      default:
+        throw std::runtime_error(
+            path +
+            ": remove failed: " + ::strerror_r(errno, buf.data(), buf.size()));
+    }
+  }
+}
+
+} // namespace Oomd

--- a/src/oomd/util/Fixture.h
+++ b/src/oomd/util/Fixture.h
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2018-present, Facebook, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#pragma once
+
+#include <functional>
+#include <initializer_list>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+namespace Oomd {
+
+// Fixture is a utility class for unit tests to encode their fixture files and
+// materialize them in run time in some temporary directory.
+class Fixture {
+ public:
+  typedef std::function<void(const std::string& path, const std::string& name)>
+      materializeFunc;
+
+  // Dirent to be materialized into a file or directory
+  class DirEntry {
+   public:
+    explicit DirEntry(materializeFunc materialize)
+        : materialize_(materialize) {}
+    void materialize(const std::string& path, const std::string& name) const {
+      materialize_(path, name);
+    }
+
+   private:
+    const materializeFunc materialize_;
+  };
+
+  // Helper functions to create different named DirEntries so that we can
+  // represent a directory tree with initializer_list in a single statement.
+  typedef std::pair<const std::string, DirEntry> DirEntryPair;
+  static DirEntryPair makeFile(
+      const std::string& name,
+      const std::string& content = "");
+  static DirEntryPair makeDir(
+      const std::string& name,
+      std::unordered_map<std::string, DirEntry> entries = {});
+
+  // utility functions that interact with file system
+  static std::string mkdtempChecked();
+  static void mkdirsChecked(
+      const std::string& path,
+      const std::string& prefix = "");
+  static void writeChecked(const std::string& path, const std::string& content);
+  static void rmrChecked(const std::string& path);
+};
+} // namespace Oomd

--- a/src/oomd/util/FixtureTest.cpp
+++ b/src/oomd/util/FixtureTest.cpp
@@ -1,0 +1,183 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+#include <dirent.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <gtest/gtest.h>
+#include <stdio.h>
+
+#include <string>
+#include <unordered_set>
+#include <vector>
+
+#include <oomd/util/Fixture.h>
+#include <oomd/util/Util.h>
+
+using namespace Oomd;
+using namespace testing;
+
+class FixtureTest : public ::testing::Test {
+ protected:
+  // remove all temp directories
+  void TearDown() override {
+    DIR* dir;
+    std::string failureMsg = "";
+    for (const auto& tempDir : tempDirs_) {
+      dir = ::opendir(tempDir.c_str());
+      if (dir != nullptr) {
+        ::closedir(dir);
+        // call `rm -r '$tempDir'` to remove recursively
+        const auto& cmd = "rm -r '" + tempDir + "'";
+        auto stream = ::popen(cmd.c_str(), "r");
+        if (stream != nullptr) {
+          ::pclose(stream);
+        }
+        dir = ::opendir(tempDir.c_str());
+        if (dir != nullptr || errno != ENOENT) {
+          failureMsg += " " + tempDir;
+        }
+      }
+    }
+    if (failureMsg != "") {
+      FAIL() << "remove failed:" + failureMsg;
+    }
+  }
+
+  std::unordered_set<std::string> tempDirs_;
+};
+
+TEST_F(FixtureTest, TestMkdtempChecked) {
+  DIR* dir;
+  std::string tempDir;
+
+  for (int i = 0; i < 100; i++) {
+    EXPECT_NO_THROW(tempDir = Fixture::mkdtempChecked());
+    // directory exists
+    EXPECT_TRUE((dir = ::opendir(tempDir.c_str())) && ::closedir(dir) == 0);
+    // directory not already seen
+    EXPECT_TRUE(tempDirs_.find(tempDir) == tempDirs_.end());
+    tempDirs_.insert(tempDir);
+  }
+}
+
+TEST_F(FixtureTest, TestMkdirsChecked) {
+  DIR* dir;
+  std::string tempDir;
+  std::string path;
+
+  EXPECT_NO_THROW(tempDir = Fixture::mkdtempChecked());
+  tempDirs_.insert(tempDir);
+
+  // nothing should happen
+  EXPECT_NO_THROW(Fixture::mkdirsChecked(tempDir));
+
+  // should ignore repeated slashes
+  EXPECT_NO_THROW(Fixture::mkdirsChecked("A//B///C/", tempDir));
+  path = tempDir + "/A/B/C";
+  EXPECT_TRUE((dir = ::opendir(path.c_str())) && ::closedir(dir) == 0);
+
+  // should create D without touching A
+  EXPECT_NO_THROW(Fixture::mkdirsChecked("A/D", tempDir));
+  path = tempDir + "/A/B/C";
+  EXPECT_TRUE((dir = ::opendir(path.c_str())) && ::closedir(dir) == 0);
+  path = tempDir + "/A/D";
+  EXPECT_TRUE((dir = ::opendir(path.c_str())) && ::closedir(dir) == 0);
+}
+
+TEST_F(FixtureTest, TestWriteChecked) {
+  std::vector<char> buf(1024);
+  std::string tempDir;
+
+  EXPECT_NO_THROW(tempDir = Fixture::mkdtempChecked());
+  tempDirs_.insert(tempDir);
+  const auto filepath = tempDir + "/writetest.txt";
+  const std::string content = "Hello, Facebook!\nHello, world!\n";
+  const std::string newContent = "Bye, Facebook!\nHello again, world!\n";
+
+  // create and write
+  EXPECT_NO_THROW(Fixture::writeChecked(filepath, content));
+  int fd = ::open(filepath.c_str(), O_RDONLY);
+  EXPECT_GE(fd, 0);
+  int bytes_read = Util::readFull(fd, buf.data(), content.length());
+  ::close(fd);
+  EXPECT_EQ(bytes_read, content.length());
+  EXPECT_EQ(std::string(buf.data(), content.length()), content);
+
+  // overwrite
+  EXPECT_NO_THROW(Fixture::writeChecked(filepath, newContent));
+  fd = ::open(filepath.c_str(), O_RDONLY);
+  EXPECT_GE(fd, 0);
+  bytes_read = Util::readFull(fd, buf.data(), newContent.length());
+  ::close(fd);
+  EXPECT_EQ(bytes_read, newContent.length());
+  EXPECT_EQ(std::string(buf.data(), newContent.length()), newContent);
+}
+
+TEST_F(FixtureTest, TestRmrChecked) {
+  DIR* dir;
+  std::string tempDir;
+
+  EXPECT_NO_THROW({
+    // create directory tree
+    tempDir = Fixture::mkdtempChecked();
+    tempDirs_.insert(tempDir);
+    Fixture::mkdirsChecked("A/B/C", tempDir);
+    Fixture::mkdirsChecked("D/E", tempDir);
+    Fixture::writeChecked(tempDir + "/file1", "file1 content");
+    Fixture::writeChecked(tempDir + "/A/file2", "file2 content");
+    Fixture::writeChecked(tempDir + "/D/E/file3", "file3 content");
+    Fixture::rmrChecked(tempDir);
+  });
+
+  tempDirs_.erase(tempDir);
+  // check file does not exist
+  dir = ::opendir(tempDir.c_str());
+  if (dir != nullptr) {
+    ::closedir(dir);
+    FAIL() << "Failed to remove tempDir: " + tempDir;
+  } else {
+    EXPECT_TRUE(errno == ENOENT);
+  }
+}
+
+bool verifyFile(const std::string& filepath, const std::string& content) {
+  int fd = ::open(filepath.c_str(), O_RDONLY);
+  if (fd < 0) {
+    return false;
+  }
+  std::vector<char> buf(content.size());
+  ssize_t count = Util::readFull(fd, buf.data(), content.size());
+  ::close(fd);
+  return std::string(buf.data(), count) == content;
+}
+
+TEST_F(FixtureTest, TestMaterialize) {
+  DIR* dir;
+  std::string tempDir;
+
+  EXPECT_NO_THROW(tempDir = Fixture::mkdtempChecked());
+  tempDirs_.insert(tempDir);
+  const auto fixture = Fixture::makeDir(
+      "root",
+      {Fixture::makeDir(
+           "A",
+           {Fixture::makeDir("B", {Fixture::makeDir("C")}),
+            Fixture::makeFile("file2", "file2 content")}),
+
+       Fixture::makeDir(
+           "D",
+           {Fixture::makeDir(
+               "E", {Fixture::makeFile("file3", "file3 content")})}),
+       Fixture::makeFile("file1", "file1 content")});
+  EXPECT_NO_THROW(fixture.second.materialize(tempDir, fixture.first));
+
+  auto root = tempDir + "/" + "root";
+  auto path = root + "/A/B/C";
+  EXPECT_TRUE((dir = ::opendir(path.c_str())) && ::closedir(dir) == 0);
+  path = root + "/A/file2";
+  EXPECT_TRUE(verifyFile(path, "file2 content"));
+  path = root + "/D/E/file3";
+  EXPECT_TRUE(verifyFile(path, "file3 content"));
+  path = root + "/file1";
+  EXPECT_TRUE(verifyFile(path, "file1 content"));
+}


### PR DESCRIPTION
Summary: All fixtures used by FsTest are now encoded into a `Dir` object in `FsFixture.cpp` and generated in run time. Existing fixtures will be removed after all tests have migrated to this new fixture generation framework.

Reviewed By: danobi

Differential Revision: D17108229

