### PR TITLE
Add requirement for Meson 0.45+ to build oomd

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,6 @@
 project('oomd', 'cpp',
   version : '0.2.0',
+  meson_version : '>= 0.45',
   license : 'GPL2',
   default_options : ['stdsplit=false', 'cpp_std=c++17'])
 


### PR DESCRIPTION
Summary:
While technically it builds ok with 0.44, we get a warning ("WARNING: Passed invalid keyword argument 'main' in meson.build line 144.") due to issue https://github.com/mesonbuild/meson/issues/2828

Meson 0.43 doesn't work at all ("Value 'c++17' for combo option 'cpp_std' is not one of the choices.")

Let's add a requirement for Meson 0.45+, since Fedora 30 has a newer Meson than that and if we want to build for RHEL 8/CentOS 8 we'll be able to use one from EPEL-8 (when available) that is likely to be newer than that.

Differential Revision: D17332599

