### PR TITLE
Fix warning cannot open io.stat

### DIFF
--- a/src/oomd/Oomd.cpp
+++ b/src/oomd/Oomd.cpp
@@ -269,13 +269,15 @@ bool Oomd::updateContextCgroup(const CgroupPath& path, OomdContext& ctx) {
   double io_cost_cumulative = 0;
   if (io_devs_.size() != 0) {
     IOStat io_stat;
-    try {
+    if (std::any_of(controllers.begin(), controllers.end(), [](std::string& s) {
+          return s == "io";
+        })) {
       io_stat = Fs::readIostat(absolute_cgroup_path);
-    } catch (const std::exception& ex) {
+    } else {
       if (!warned_io_stat_.count(absolute_cgroup_path)) {
         warned_io_stat_.emplace(absolute_cgroup_path);
-        OLOG << "IO stat unavailable on " << absolute_cgroup_path << ": "
-             << ex.what();
+        OLOG << "WARNING: cgroup io controller unavailable on "
+             << absolute_cgroup_path << ". io cost will be zero.";
       }
       io_stat = {};
     }


### PR DESCRIPTION
Summary:
Some cgroups does not have io.stat file because io controller is not enabled. The existing way calls readIostat and when there is an exception, we catch and warn once.

However, this never works as expected because internally readFileByLine does not throw exception but instead log to OLOG. This causes some log pollution when some monitored cgroup has no io controller.

The right way is to check for io controller instead of catching exception.

Differential Revision: D17634818

