### PR TITLE
meson config: avoid a version warning

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -107,14 +107,12 @@ configure_file(
     input : 'src/oomd/etc/oomd.service.in',
     output : 'oomd.service',
     configuration : substs,
-    install : true,
     install_dir : systemunitdir)
 
 configure_file(
     input : 'src/oomd/etc/desktop.json',
     output : 'oomd.json',
     configuration : substs,
-    install : true,
     install_dir : oomdconfdir)
 
 # Core tests


### PR DESCRIPTION
Meson warns that

    WARNING: Project targetting '>= 0.45' but tried to use feature introduced in '0.50.0': install arg in configure_file

install defaults to true if install_dir is set, so this is unnecessary.

Testing done:

    $ sudo ninja install
    Installing oomd to /usr/local/bin
    Installing /home/mmullins/projects/oomd/build/oomd.service to /usr/local/lib/systemd/system
    Installing /home/mmullins/projects/oomd/build/oomd.json to /usr/local/etc/oomd