### PR TITLE
scanf: use SCNu64 macro for reading into uint64_t

### DIFF
--- a/src/oomd/util/Fs.cpp
+++ b/src/oomd/util/Fs.cpp
@@ -517,7 +517,8 @@ IOStat Fs::readIostat(const std::string& path) {
     int major, minor;
     int ret = sscanf(
         line.c_str(),
-        "%d:%d rbytes=%" SCNu64 " wbytes=%" SCNu64 " rios=%" SCNu64 " wios=%" SCNu64 " dbytes=%" SCNu64 " dios=%" SCNu64 "\n",
+        "%d:%d rbytes=%" SCNu64 " wbytes=%" SCNu64 " rios=%" SCNu64
+        " wios=%" SCNu64 " dbytes=%" SCNu64 " dios=%" SCNu64 "\n",
         &major,
         &minor,
         &dev_io_stat.rbytes,

--- a/src/oomd/util/Fs.cpp
+++ b/src/oomd/util/Fs.cpp
@@ -26,6 +26,7 @@
 #include <sys/xattr.h>
 #include <unistd.h>
 
+#include <cinttypes>
 #include <deque>
 #include <fstream>
 #include <utility>
@@ -516,7 +517,7 @@ IOStat Fs::readIostat(const std::string& path) {
     int major, minor;
     int ret = sscanf(
         line.c_str(),
-        "%d:%d rbytes=%lu wbytes=%lu rios=%lu wios=%lu dbytes=%lu dios=%lu\n",
+        "%d:%d rbytes=%" SCNu64 " wbytes=%" SCNu64 " rios=%" SCNu64 " wios=%" SCNu64 " dbytes=%" SCNu64 " dios=%" SCNu64 "\n",
         &major,
         &minor,
         &dev_io_stat.rbytes,


### PR DESCRIPTION
This avoids

    warning: format ‘%lu’ expects argument of type ‘long unsigned int*’, but argument 10 has type ‘int64_t*’ {aka ‘long long int*’}

as observed on a 32-bit system with GCC 9.2.