### PR TITLE
oomd: Just use plain old getcwd instead of std::filesystem

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -151,22 +151,11 @@ if gtest_dep.found() and gmock_dep.found()
         sources = test_source_tuple[1]
 
         executable_name_suffix = test_name + '_tests'
-
-        # Remove once GCC 8+ is more ubiquitous with non-experimental
-        # <filesystem>
-        local_deps = deps
-        if test_name == 'oomd'
-          fs_dep = dependency('stdc++fs', required : false)
-          if fs_dep.found()
-            local_deps += [fs_dep]
-          endif
-        endif
-
         test_executable = executable('oomd_' + executable_name_suffix,
             sources,
             include_directories : inc,
             cpp_args : cpp_args,
-            dependencies : local_deps,
+            dependencies : deps,
             link_whole : [oomd_lib, oomd_fixture_lib])
         test(executable_name_suffix,
              test_executable,


### PR DESCRIPTION
Summary:
Who'd have known it would be so overcomplicated:

1. Some versions of GCC want <experimental/filesystem>, some want <filesystem>,
   some may have experimental versions which may not do what we want, some need
   linking stdc++fs...
2. Some versions of Clang need you to link stdc++experimental, some want
   -lc++fs, some don't need anything...

Reviewed By: lnyng

Differential Revision: D18813191

