### PR TITLE
Add ny_dying_descendants plugin

### DIFF
--- a/docs/core_plugins.md
+++ b/docs/core_plugins.md
@@ -127,6 +127,26 @@ otherwise.
 When `negate` is `true`, if `cgroup` doesn't exist, CONTINUE. STOP
 otherwise.
 
+## nr_dying_descendants
+
+### Arguments
+
+    cgroup
+    count
+    lte=true (optional)
+    negate=false (optional)
+
+### Description
+
+`cgroup` supports comma separated arguments and wildcards. The plugin triggers
+if any of the globbed cgroups matches the condition.
+
+When `lte` is `true`, if `nr_dying_descendants(cgroup) <= count`, CONTINUE.
+STOP otherwise.
+
+When `lte` is `false`, if `nr_dying_descendants(cgroup) > count`, CONTINUE.
+STOP otherwise.
+
 ## dump_cgroup_overview
 
 ### Arguments

--- a/meson.build
+++ b/meson.build
@@ -41,6 +41,7 @@ srcs = files('''
     src/oomd/util/Util.cpp
     src/oomd/plugins/MemoryAbove.cpp
     src/oomd/plugins/MemoryReclaim.cpp
+    src/oomd/plugins/NrDyingDescendants.cpp
     src/oomd/plugins/PressureAbove.cpp
     src/oomd/plugins/PressureRisingBeyond.cpp
     src/oomd/plugins/SwapFree.cpp

--- a/src/oomd/Oomd.cpp
+++ b/src/oomd/Oomd.cpp
@@ -231,12 +231,14 @@ bool Oomd::updateContextRoot(const CgroupPath& path, OomdContext& ctx) {
   auto pressures = Fs::readMempressure("/");
   auto io_pressure = readIopressureWarnOnce("/");
   auto current = Fs::readMemcurrent("/");
+  auto nr_dying_descendants = Fs::getNrDyingDescendants(path.cgroupFs());
 
   ctx.setCgroupContext(
       path,
       {.pressure = pressures,
        .io_pressure = io_pressure,
-       .current_usage = current});
+       .current_usage = current,
+       .nr_dying_descendants = nr_dying_descendants});
 
   return true;
 }
@@ -291,6 +293,7 @@ bool Oomd::updateContextCgroup(const CgroupPath& path, OomdContext& ctx) {
     }
     io_cost_cumulative = calculateIOCostCumulative(io_stat);
   }
+  auto nr_dying_descendants = Fs::getNrDyingDescendants(absolute_cgroup_path);
 
   ctx.setCgroupContext(
       path,
@@ -304,7 +307,8 @@ bool Oomd::updateContextCgroup(const CgroupPath& path, OomdContext& ctx) {
        .memory_high = memhigh,
        .memory_high_tmp = memhigh_tmp,
        .memory_max = memmax,
-       .io_cost_cumulative = io_cost_cumulative});
+       .io_cost_cumulative = io_cost_cumulative,
+       .nr_dying_descendants = nr_dying_descendants});
 
   return true;
 }

--- a/src/oomd/fixtures/FsFixture.cpp
+++ b/src/oomd/fixtures/FsFixture.cpp
@@ -187,6 +187,10 @@ const auto kEntCgroup = F::makeDir(
             F::makeFile("cgroup.controllers", "cpu io memory pids\n"),
             F::makeFile("cgroup.procs", "123\n"),
             F::makeFile(
+                "cgroup.stat",
+                "nr_descendants 34\n"
+                "nr_dying_descendants 27\n"),
+            F::makeFile(
                 "io.pressure",
                 "some avg10=1.12 avg60=2.23 avg300=3.34 total=134829384401\n"
                 "full avg10=4.45 avg60=5.56 avg300=6.67 total=128544748771\n"),

--- a/src/oomd/include/Types.h
+++ b/src/oomd/include/Types.h
@@ -82,6 +82,7 @@ class CgroupContext {
   int64_t memory_adj{0};
   double io_cost_cumulative{0}; // Dot product between io stat and coeffs
   double io_cost_rate{0}; // change of cumulative divided by interval in seconds
+  int64_t nr_dying_descendants{0};
 
   int64_t effective_usage() const {
     return current_usage * memory_scale - memory_protection + memory_adj;

--- a/src/oomd/plugins/NrDyingDescendants.cpp
+++ b/src/oomd/plugins/NrDyingDescendants.cpp
@@ -1,0 +1,100 @@
+/*
+ * Copyright (C) 2018-present, Facebook, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include "oomd/plugins/NrDyingDescendants.h"
+
+#include "oomd/Log.h"
+#include "oomd/PluginRegistry.h"
+#include "oomd/util/Util.h"
+
+static constexpr auto kCgroupFs = "/sys/fs/cgroup/";
+
+namespace Oomd {
+
+REGISTER_PLUGIN(nr_dying_descendants, NrDyingDescendants::create);
+
+int NrDyingDescendants::init(
+    Engine::MonitoredResources& resources,
+    const Engine::PluginArgs& args) {
+  if (args.find("cgroup") != args.end()) {
+    auto cgroup_fs =
+        (args.find("cgroup_fs") != args.end() ? args.at("cgroup_fs")
+                                              : kCgroupFs);
+
+    auto cgroups = Util::split(args.at("cgroup"), ',');
+    for (const auto& c : cgroups) {
+      resources.emplace(cgroup_fs, c);
+      cgroups_.emplace(cgroup_fs, c);
+    }
+  } else {
+    OLOG << "Argument=cgroup not present";
+    return 1;
+  }
+
+  if (args.find("count") != args.end()) {
+    int val = std::stoi(args.at("count"));
+    if (val < 0) {
+      OLOG << "Argument=count must be non-negative";
+    }
+    count_ = val;
+  } else {
+    OLOG << "Argument=count not present";
+  }
+
+  if (args.find("lte") != args.end()) {
+    const std::string& val = args.at("lte");
+
+    if (val == "true" || val == "True" || val == "1") {
+      lte_ = true;
+    }
+
+    if (val == "false" || val == "False" || val == "0") {
+      lte_ = false;
+    }
+  }
+
+  if (args.find("debug") != args.end()) {
+    const std::string& val = args.at("debug");
+
+    if (val == "true" || val == "True" || val == "1") {
+      debug_ = true;
+    }
+  }
+
+  // Success
+  return 0;
+}
+
+Engine::PluginRet NrDyingDescendants::run(OomdContext& ctx) {
+  auto cgroups = ctx.reverseSort();
+  OomdContext::removeSiblingCgroups(cgroups_, cgroups);
+
+  for (const auto& [name, cgroup_ctx] : cgroups) {
+    int64_t nr = cgroup_ctx.nr_dying_descendants;
+    if ((lte_ && nr <= count_) || (!lte_ && nr > count_)) {
+      if (debug_) {
+        OLOG << "nr_dying_descendants=" << nr << (lte_ ? " <= " : " > ")
+             << "count=" << count_;
+      }
+      return Engine::PluginRet::CONTINUE;
+    }
+  }
+
+  return Engine::PluginRet::STOP;
+}
+
+} // namespace Oomd

--- a/src/oomd/plugins/NrDyingDescendants.h
+++ b/src/oomd/plugins/NrDyingDescendants.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2018-present, Facebook, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#pragma once
+
+#include <unordered_set>
+
+#include "oomd/engine/BasePlugin.h"
+
+namespace Oomd {
+
+class NrDyingDescendants : public Oomd::Engine::BasePlugin {
+ public:
+  int init(
+      Engine::MonitoredResources& resources,
+      const Engine::PluginArgs& args) override;
+
+  Engine::PluginRet run(OomdContext& ctx) override;
+
+  static NrDyingDescendants* create() {
+    return new NrDyingDescendants();
+  }
+
+  ~NrDyingDescendants() = default;
+
+ private:
+  std::unordered_set<CgroupPath> cgroups_;
+  int64_t count_{0};
+  bool lte_{true}; // less than or equal
+  bool debug_{false};
+};
+
+} // namespace Oomd

--- a/src/oomd/util/Fs.cpp
+++ b/src/oomd/util/Fs.cpp
@@ -460,13 +460,13 @@ std::unordered_map<std::string, int64_t> Fs::getMeminfo(
   return map;
 }
 
-std::unordered_map<std::string, int64_t> Fs::getMemstat(
-    const std::string& path) {
+std::unordered_map<std::string, int64_t> Fs::getMemstatLike(
+    const std::string& file) {
   char name[256] = {0};
   uint64_t val;
   std::unordered_map<std::string, int64_t> map;
 
-  auto lines = readFileByLine(path + "/" + kMemStatFile);
+  auto lines = readFileByLine(file);
   for (const auto& line : lines) {
     int ret = sscanf(line.c_str(), "%255s %" SCNu64 "\n", name, &val);
     if (ret == 2) {
@@ -475,6 +475,11 @@ std::unordered_map<std::string, int64_t> Fs::getMemstat(
   }
 
   return map;
+}
+
+std::unordered_map<std::string, int64_t> Fs::getMemstat(
+    const std::string& path) {
+  return getMemstatLike(path + "/" + kMemStatFile);
 }
 
 ResourcePressure Fs::readIopressure(
@@ -556,6 +561,12 @@ void Fs::writeMemhightmp(
     throw bad_control_file(
         file_name + ": write failed: " + ::strerror_r(errno, buf, sizeof(buf)));
   }
+}
+
+int64_t Fs::getNrDyingDescendants(const std::string& path) {
+  auto map = getMemstatLike(path + "/" + kCgroupStatFile);
+  // Will return 0 for missing entries
+  return map["nr_dying_descendants"];
 }
 
 bool Fs::setxattr(

--- a/src/oomd/util/Fs.h
+++ b/src/oomd/util/Fs.h
@@ -48,6 +48,7 @@ class Fs {
   static constexpr auto kMemHighTmpFile = "memory.high.tmp";
   static constexpr auto kMemMinFile = "memory.min";
   static constexpr auto kMemStatFile = "memory.stat";
+  static constexpr auto kCgroupStatFile = "cgroup.stat";
   static constexpr auto kMemSwapCurrentFile = "memory.swap.current";
   static constexpr auto kIoPressureFile = "io.pressure";
   static constexpr auto kIoStatFile = "io.stat";
@@ -131,6 +132,8 @@ class Fs {
       int64_t value,
       std::chrono::microseconds duration);
 
+  static int64_t getNrDyingDescendants(const std::string& path);
+
   static IOStat readIostat(const std::string& path);
 
   static std::unordered_map<std::string, int64_t> getVmstat(
@@ -164,6 +167,10 @@ class Fs {
       const std::string& path = "/sys/dev/block");
 
   static bool hasGlob(const std::string& s);
+
+ private:
+  static std::unordered_map<std::string, int64_t> getMemstatLike(
+      const std::string& file);
 };
 
 } // namespace Oomd

--- a/src/oomd/util/FsTest.cpp
+++ b/src/oomd/util/FsTest.cpp
@@ -162,6 +162,12 @@ TEST_F(FsTest, GetPids) {
   EXPECT_THAT(pids_r, Contains(789));
 }
 
+TEST_F(FsTest, GetNrDying) {
+  auto dir = fixture_.cgroupDataDir();
+  int64_t nr = Fs::getNrDyingDescendants(dir);
+  EXPECT_EQ(nr, 27);
+}
+
 TEST_F(FsTest, ReadMemoryCurrent) {
   auto dir = fixture_.cgroupDataDir();
   EXPECT_EQ(Fs::readMemcurrent(dir), 987654321);


### PR DESCRIPTION
Current kernels have an issue where if there are too many "dying
cgroups" (ie. cgroups have not yet been reclaimed), the kernel can waste
a lot of time iterating through dying cgroups looking for pages to
reclaim. This wasted time can trigger heavy memory pressure if a process
tries to allocate a lot of memory even if the system appears to have
evictable memory.

The proper fix is for the kernel to less aggressively defer reclaim. In
the meantime, we will gate triggering kills on having <= N dying
cgroups.