### PR TITLE
Regression build break fix

### DIFF
--- a/src/oomd/plugins/DumpKillInfoNoOp.cpp
+++ b/src/oomd/plugins/DumpKillInfoNoOp.cpp
@@ -24,6 +24,6 @@ void BaseKillPlugin::dumpKillInfo(
     const CgroupPath& killed_group,
     const CgroupContext& context,
     const ActionContext& action_context,
-    bool dry = false) const {}
+    bool dry) const {}
 
 } // namespace Oomd


### PR DESCRIPTION
Summary: Caused by my previous commit - default value in method definition.

Reviewed By: danobi

Differential Revision: D19952727

