### PR TITLE
Take an exclusive runtime lock on startup

### DIFF
--- a/docs/stats.md
+++ b/docs/stats.md
@@ -48,10 +48,6 @@ It can be also be queried from a different process using the StatsClient class.
 
   Command line flags:
 
-#####  `-s [SOCKET_PATH]`
-
-  If a custom socket path was chosen for the stats collection, include it here.
-
 ##### `-d`
 
   Dumps all accumulated stats to stdout in a JSON string.

--- a/meson.build
+++ b/meson.build
@@ -92,6 +92,7 @@ executable('oomd',
            files('src/oomd/Main.cpp'),
            include_directories : inc,
            cpp_args : cpp_args,
+           link_args : ['-lstdc++fs'],
            dependencies : deps,
            install: true,
            link_whole : oomd_lib)

--- a/src/oomd/Main.cpp
+++ b/src/oomd/Main.cpp
@@ -363,13 +363,6 @@ int main(int argc, char** argv) {
     return 1;
   }
 
-  if (!Oomd::Stats::init(stats_socket_path)) {
-    OLOG << "Stats module failed to initialize";
-    return 1;
-  }
-
-  initializeCoreStats();
-
   if (should_check_config) {
     auto ir = parseConfig(flag_conf_file);
     if (!ir) {
@@ -386,6 +379,14 @@ int main(int argc, char** argv) {
 
     return 0;
   }
+
+  // NB: do not start stats module unless we are going to daemonize
+  if (!Oomd::Stats::init(stats_socket_path)) {
+    OLOG << "Stats module failed to initialize";
+    return 1;
+  }
+
+  initializeCoreStats();
 
   if (!system_reqs_met()) {
     std::cerr << "System requirements not met\n";

--- a/src/oomd/Stats.cpp
+++ b/src/oomd/Stats.cpp
@@ -106,30 +106,6 @@ bool& Stats::isInitInternal() {
 
 bool Stats::startSocket() {
   std::array<char, 64> err_buf = {};
-  size_t dir_end = stats_socket_path_.find_last_of("/");
-  // Iteratively checks if dirs in path exist, creates them if not
-  if (dir_end != std::string::npos) {
-    std::string dirs = stats_socket_path_.substr(0, dir_end);
-    size_t pos = 0;
-    if (dirs[0] == '/') {
-      pos++;
-    }
-    while (pos < dirs.size()) {
-      pos = dirs.find('/', pos);
-      if (pos == std::string::npos) {
-        pos = dir_end;
-      }
-      std::string curr_path = dirs.substr(0, pos);
-      int res = ::mkdir(curr_path.c_str(), S_IRWXU | S_IRWXG | S_IRWXO);
-      if (res != 0 && errno != EEXIST) {
-        OLOG << "Making socket dir error: "
-             << ::strerror_r(errno, err_buf.data(), err_buf.size()) << ": "
-             << curr_path;
-        return false;
-      }
-      pos++;
-    }
-  }
 
   sockfd_ = ::socket(AF_UNIX, SOCK_STREAM, 0);
   if (sockfd_ < 0) {


### PR DESCRIPTION
Summary:
We don't want 2 daemonized oomd instances running on one host.
Create and take a filelock on startup.

Reviewed By: lnyng

Differential Revision: D20481162

