### PR TITLE
Redesign CgroupContext

### DIFF
--- a/src/oomd/CgroupContext.cpp
+++ b/src/oomd/CgroupContext.cpp
@@ -1,0 +1,263 @@
+/*
+ * Copyright (C) 2018-present, Facebook, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include "oomd/CgroupContext.h"
+
+#include "oomd/NewOomdContext.h"
+
+namespace Oomd {
+
+NewCgroupContext::NewCgroupContext(OomdContext& ctx, const CgroupPath& cgroup)
+    : ctx_(ctx),
+      cgroup_(cgroup),
+      cgroup_dir_(Fs::DirFd::open(cgroup.absolutePath())),
+      data_(std::make_unique<CgroupData>()) {}
+
+bool NewCgroupContext::refresh() {
+  // Check if cgroup still exists
+  if (!cgroup_dir_.checkValid()) {
+    return false;
+  }
+
+  archive_ = {.average_usage = data_->average_usage,
+              .io_cost_cumulative = data_->io_cost_cumulative};
+  *data_ = {};
+  return true;
+}
+
+/*
+ * Use macro to define proxy functions to access the underlying data object.
+ * If a field is not set, set it with the result of a given expression. If the
+ * expression throws Fs::bad_control_file (most likely cgroup is gone), we set
+ * the err to INVALID_CGROUP if it's not nullptr. The given expression can also
+ * use the err pointer as a mechanism to return error without throwing.
+ *
+ * Because data_ is a pointer, we can do this lazy set and get with const
+ * function signature.
+ */
+#define __PROXY(field, expr, rettype)                 \
+  rettype NewCgroupContext::field(Error* err) const { \
+    if (!data_->field) {                              \
+      try {                                           \
+        data_->field = (expr);                        \
+      } catch (const Fs::bad_control_file&) {         \
+        if (err) {                                    \
+          *err = Error::INVALID_CGROUP;               \
+        }                                             \
+      }                                               \
+    }                                                 \
+    return data_->field;                              \
+  }
+
+#define FIELD_TYPE(field) decltype(NewCgroupContext::CgroupData::field)
+#define PROXY(field, expr) __PROXY(field, expr, FIELD_TYPE(field))
+#define PROXY_CONST_REF(field, expr) \
+  __PROXY(field, expr, const FIELD_TYPE(field)&)
+
+PROXY_CONST_REF(children, getChildren())
+PROXY_CONST_REF(mem_pressure, getMemPressure())
+PROXY_CONST_REF(io_pressure, getIoPressure())
+PROXY_CONST_REF(memory_stat, Fs::getMemstatAt(cgroup_dir_))
+PROXY_CONST_REF(io_stat, Fs::readIostatAt(cgroup_dir_))
+PROXY(current_usage, getMemcurrent())
+PROXY(swap_usage, Fs::readSwapCurrentAt(cgroup_dir_))
+PROXY(memory_low, Fs::readMemlowAt(cgroup_dir_))
+PROXY(memory_min, Fs::readMemminAt(cgroup_dir_))
+PROXY(memory_high, Fs::readMemhighAt(cgroup_dir_))
+PROXY(memory_high_tmp, Fs::readMemhightmpAt(cgroup_dir_))
+PROXY(memory_max, Fs::readMemmaxAt(cgroup_dir_))
+PROXY(nr_dying_descendants, Fs::getNrDyingDescendantsAt(cgroup_dir_))
+PROXY(io_cost_cumulative, getIoCostCumulative(err))
+PROXY(memory_protection, getMemoryProtection(err))
+PROXY(io_cost_rate, getIoCostRate(err))
+PROXY(average_usage, getAverageUsage(err))
+
+std::optional<int64_t> NewCgroupContext::anon_usage(Error* err) const {
+  if (const auto& stat = memory_stat(err)) {
+    if (auto anon = stat->find("anon"); anon != stat->end()) {
+      return anon->second;
+    } else if (err) {
+      *err = Error::INVALID_CGROUP;
+    }
+  }
+  return 0;
+}
+
+std::optional<int64_t> NewCgroupContext::effective_usage(
+    Error* err,
+    int64_t memory_scale,
+    int64_t memory_adj) const {
+  if (!current_usage(err) || !memory_protection(err)) {
+    return std::nullopt;
+  }
+  return *current_usage() * memory_scale - *memory_protection() + memory_adj;
+}
+
+std::vector<std::string> NewCgroupContext::getChildren() const {
+  return Fs::readDir(cgroup_.absolutePath(), Fs::DE_DIR).dirs;
+}
+
+ResourcePressure NewCgroupContext::getMemPressure() const {
+  return cgroup_.isRoot() ? Fs::readRootMempressure()
+                          : Fs::readMempressureAt(cgroup_dir_);
+}
+
+ResourcePressure NewCgroupContext::getIoPressure() const {
+  return cgroup_.isRoot() ? Fs::readRootIopressure()
+                          : Fs::readIopressureAt(cgroup_dir_);
+}
+
+int64_t NewCgroupContext::getMemcurrent() const {
+  return cgroup_.isRoot() ? Fs::readRootMemcurrent()
+                          : Fs::readMemcurrentAt(cgroup_dir_);
+}
+
+namespace {
+std::optional<int64_t> rawProtection(
+    const NewCgroupContext& ctx,
+    NewCgroupContext::Error* err = nullptr) {
+  if (!ctx.current_usage(err) || !ctx.memory_min(err) || !ctx.memory_low(err)) {
+    return std::nullopt;
+  }
+  return std::min(
+      ctx.current_usage(), std::max(ctx.memory_min(), ctx.memory_low()));
+}
+
+std::optional<int64_t> normalizedProtection(
+    const NewCgroupContext& ctx,
+    const NewCgroupContext& parent_ctx,
+    int64_t protection_sum,
+    NewCgroupContext::Error* err = nullptr) {
+  if (protection_sum == 0) {
+    // If the cgroup isn't using any memory then it's trivially true it's
+    // not receiving any protection
+    return 0;
+  } else {
+    auto raw_prot = rawProtection(ctx, err);
+    if (!raw_prot) {
+      return std::nullopt;
+    }
+    auto parent_prot = parent_ctx.memory_protection(err);
+    if (!parent_prot) {
+      return std::nullopt;
+    }
+    return *raw_prot * std::min(1.0, 1.0 * *parent_prot / protection_sum);
+  }
+}
+} // namespace
+
+/*
+ * Calculate memory protection, taking into account actual distribution of
+ * memory protection.
+ *
+ * Let's say R(cgrp) is the raw protection amount a cgroup has according to its
+ * own config, P(cgrp) is the amount of actual protection it gets. This function
+ * returns P(cgrp).
+ *
+ * Let R(cgrp) = min(cgrp.memory.current, max(cgrp.memory.min,
+ * cgrp.memory.low))
+ *
+ * Then, P(cgrp) = R(cgrp) * min(1.0, P(parent) / (Sum of L(child) for each
+ * children of parent))
+ */
+std::optional<int64_t> NewCgroupContext::getMemoryProtection(Error* err) const {
+  if (cgroup_.isRoot()) {
+    return current_usage(err);
+  }
+
+  auto parent_cgroup = cgroup_.getParent();
+  if (parent_cgroup.isRoot()) {
+    // We're at a top level cgroup where P(cgrp) == R(cgrp)
+    return rawProtection(*this, err);
+  }
+  auto parent_ctx = ctx_.addToCacheAndGet(parent_cgroup);
+  if (!parent_ctx) {
+    if (err) {
+      *err = Error::INVALID_CGROUP;
+    }
+    return std::nullopt;
+  }
+
+  std::unordered_set<CgroupPath> sibling_cgroups;
+  std::vector<OomdContext::ConstCgroupContextRef> siblings;
+  if (auto children = parent_ctx->get().children(err)) {
+    for (const auto& name : *children) {
+      sibling_cgroups.insert(parent_cgroup.getChild(name));
+    }
+    siblings = ctx_.addToCacheAndGet(sibling_cgroups);
+  } else {
+    return std::nullopt;
+  }
+
+  int64_t protection_sum = 0;
+  for (auto sibling_ctx : siblings) {
+    protection_sum += rawProtection(sibling_ctx).value_or(0);
+  }
+  return normalizedProtection(*this, *parent_ctx, protection_sum, err);
+}
+
+std::optional<double> NewCgroupContext::getIoCostCumulative(Error* err) const {
+  if (!io_stat(err)) {
+    return std::nullopt;
+  }
+  const auto& params = ctx_.getParams();
+  double cost = 0.0;
+  // calculate the sum of cumulative io cost on all devices.
+  for (const auto& stat : *io_stat()) {
+    // only keep stats from devices we care
+    auto dev = params.io_devs.find(stat.dev_id);
+    if (dev == params.io_devs.end()) {
+      continue;
+    }
+    IOCostCoeffs coeffs;
+    switch (dev->second) {
+      case DeviceType::SSD:
+        coeffs = params.ssd_coeffs;
+        break;
+      case DeviceType::HDD:
+        coeffs = params.hdd_coeffs;
+        break;
+    }
+    // Dot product between dev io stat and io cost coeffs. A more sensible way
+    // is to do dot product between rate of change (bandwidth, iops) with coeffs
+    // but since the coeffs are constant, we can calculate rate of change later.
+    cost += stat.rios * coeffs.read_iops + stat.rbytes * coeffs.readbw +
+        stat.wios * coeffs.write_iops + stat.wbytes * coeffs.writebw +
+        stat.dios * coeffs.trim_iops + stat.dbytes * coeffs.trimbw;
+  }
+  return cost;
+}
+
+std::optional<int64_t> NewCgroupContext::getAverageUsage(Error* err) const {
+  if (!current_usage(err)) {
+    return std::nullopt;
+  }
+  auto prev_avg = archive_.average_usage.value_or(0);
+  auto decay = ctx_.getParams().average_size_decay;
+  return prev_avg * ((decay - 1) / decay) + (*current_usage() / decay);
+}
+
+std::optional<double> NewCgroupContext::getIoCostRate(Error* err) const {
+  if (!io_cost_cumulative(err)) {
+    return std::nullopt;
+  }
+  return !archive_.io_cost_cumulative
+      ? 0.0
+      : *io_cost_cumulative() - *archive_.io_cost_cumulative;
+}
+
+} // namespace Oomd

--- a/src/oomd/CgroupContext.h
+++ b/src/oomd/CgroupContext.h
@@ -1,0 +1,169 @@
+/*
+ * Copyright (C) 2018-present, Facebook, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#pragma once
+
+#include <deque>
+#include <memory>
+#include <optional>
+#include <unordered_map>
+
+#include "oomd/include/CgroupPath.h"
+#include "oomd/include/Types.h"
+#include "oomd/util/Fs.h"
+
+namespace Oomd {
+
+class OomdContext;
+/*
+ * Storage class for cgroup states. Data are retrieved from cgroupfs on access
+ * and cached until refresh() is called.
+ */
+class NewCgroupContext {
+ public:
+  // Error type when retrieving CgroupContext fields
+  enum class Error {
+    NO_ERROR = 0,
+    // Cgroup no longer exists
+    INVALID_CGROUP,
+  };
+
+  /*
+   * Create a cgroup context from its containing OomdContext and its path, which
+   * must not be a glob pattern.
+   *
+   * OomdContext is required because some data are sibling-aware, i.e. values of
+   * sibling cgroups affects its own value. It also stores ContextParams so
+   * CgroupContext won't have to duplicate it.
+   *
+   * As OomdContext is guaranteed to last longer than CgroupContext, use
+   * raw reference instead of smart pointer.
+   */
+  NewCgroupContext(OomdContext& ctx, const CgroupPath& cgroup);
+
+  /*
+   * Check if cgroup still exists and archive current data for temporal
+   * counters. Only called by the containing OomdContext, which has access to
+   * the mutable instance.
+   */
+  bool refresh();
+
+  bool isValid() const {
+    return cgroup_dir_.isValid();
+  }
+
+  const CgroupPath& cgroup() const {
+    return cgroup_;
+  }
+
+  // Accessors to cgroup fields. If error is encountered, std::nullopt will be
+  // returned and err set to corresponding error enum if it's not nullptr.
+  // Otherwise, err will stay the same and an optional with value returned.
+
+  // Names of child cgroups (not full path)
+  const std::optional<std::vector<std::string>>& children(
+      Error* err = nullptr) const;
+  const std::optional<ResourcePressure>& mem_pressure(
+      Error* err = nullptr) const;
+  const std::optional<ResourcePressure>& io_pressure(
+      Error* err = nullptr) const;
+  const std::optional<std::unordered_map<std::string, int64_t>>& memory_stat(
+      Error* err = nullptr) const;
+  const std::optional<IOStat>& io_stat(Error* err = nullptr) const;
+  std::optional<int64_t> current_usage(Error* err = nullptr) const;
+  std::optional<int64_t> swap_usage(Error* err = nullptr) const;
+  std::optional<int64_t> memory_low(Error* err = nullptr) const;
+  std::optional<int64_t> memory_min(Error* err = nullptr) const;
+  std::optional<int64_t> memory_high(Error* err = nullptr) const;
+  std::optional<int64_t> memory_high_tmp(Error* err = nullptr) const;
+  std::optional<int64_t> memory_max(Error* err = nullptr) const;
+  std::optional<int64_t> nr_dying_descendants(Error* err = nullptr) const;
+  // memory_{min,low} taking into account the distribution of it
+  std::optional<int64_t> memory_protection(Error* err = nullptr) const;
+  // Dot product between io stat and coeffs
+  std::optional<double> io_cost_cumulative(Error* err = nullptr) const;
+
+  // Below are temporal data counters, which need to be retrieved every interval
+  // to become accurate. Must invoke them in plugin prerun() if they may be used
+  // in run().
+
+  // Moving average memory usage
+  std::optional<int64_t> average_usage(Error* err = nullptr) const;
+  // Change of cumulative io cost between intervals (not normalized by time)
+  std::optional<double> io_cost_rate(Error* err = nullptr) const;
+
+  // Non-cached derived counters
+  std::optional<int64_t> anon_usage(Error* err = nullptr) const;
+  std::optional<int64_t> effective_usage(
+      Error* err = nullptr,
+      int64_t memory_scale = 1,
+      int64_t memory_adj = 0) const;
+
+ private:
+  // Test only
+  friend class TestHelper;
+
+  std::vector<std::string> getChildren() const;
+  ResourcePressure getMemPressure() const;
+  ResourcePressure getIoPressure() const;
+  int64_t getMemcurrent() const;
+  std::optional<int64_t> getMemoryProtection(Error* err) const;
+  std::optional<double> getIoCostCumulative(Error* err) const;
+  std::optional<int64_t> getAverageUsage(Error* err) const;
+  std::optional<double> getIoCostRate(Error* err) const;
+
+  struct CgroupData {
+    std::optional<std::vector<std::string>> children;
+    std::optional<ResourcePressure> mem_pressure;
+    std::optional<ResourcePressure> io_pressure;
+    std::optional<std::unordered_map<std::string, int64_t>> memory_stat;
+    std::optional<IOStat> io_stat;
+    std::optional<int64_t> current_usage;
+    std::optional<int64_t> swap_usage;
+    std::optional<int64_t> memory_low;
+    std::optional<int64_t> memory_min;
+    std::optional<int64_t> memory_high;
+    std::optional<int64_t> memory_high_tmp;
+    std::optional<int64_t> memory_max;
+    std::optional<int64_t> nr_dying_descendants;
+    // Cached derived data
+    std::optional<int64_t> memory_protection;
+    std::optional<double> io_cost_cumulative;
+    // Temporal counters
+    std::optional<int64_t> average_usage;
+    std::optional<double> io_cost_rate;
+  };
+
+  // Data required to calculate temporal counters
+  struct CgroupArchivedData {
+    std::optional<int64_t> average_usage;
+    std::optional<double> io_cost_cumulative;
+  };
+
+  OomdContext& ctx_;
+  CgroupPath cgroup_;
+  // This dir fd will be invalid whenever the cgroup is gone. Store it to
+  // prevent race when a cgroup with exact same name is recreated after removal.
+  // We check validity in refresh(). If invalid, the dir fd will be closed and
+  // OomdContext will remove this CgroupContext.
+  Fs::DirFd cgroup_dir_;
+  std::unique_ptr<CgroupData> data_;
+
+  CgroupArchivedData archive_{};
+};
+
+} // namespace Oomd

--- a/src/oomd/CgroupContextTest.cpp
+++ b/src/oomd/CgroupContextTest.cpp
@@ -1,0 +1,448 @@
+/*
+ * Copyright (C) 2018-present, Facebook, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "oomd/CgroupContext.h"
+#include "oomd/Log.h"
+#include "oomd/NewOomdContext.h"
+#include "oomd/util/Fixture.h"
+
+using namespace Oomd;
+using namespace testing;
+using F = Fixture;
+
+class CgroupContextTest : public Test {
+ public:
+  CgroupContextTest() {
+    params_.io_devs = {{"1:10", DeviceType::HDD}, {"1:11", DeviceType::SSD}};
+    params_.hdd_coeffs = {.read_iops = 6,
+                          .readbw = 5,
+                          .write_iops = 4,
+                          .writebw = 3,
+                          .trim_iops = 2,
+                          .trimbw = 1};
+    params_.ssd_coeffs = {.read_iops = 1,
+                          .readbw = 2,
+                          .write_iops = 3,
+                          .writebw = 4,
+                          .trim_iops = 5,
+                          .trimbw = 6};
+    ctx_ = OomdContext(params_);
+  }
+
+ protected:
+  void SetUp() override {
+    tempDir_ = Fixture::mkdtempChecked();
+    ctx_ = OomdContext(params_);
+  }
+
+  void TearDown() override {
+    F::rmrChecked(tempDir_);
+  }
+
+  OomdContext ctx_;
+  ContextParams params_;
+  std::string tempDir_;
+};
+
+TEST_F(CgroupContextTest, MonitorRootHost) {
+  std::string cgroup2fs_mntpt = Fs::getCgroup2MountPoint();
+  if (cgroup2fs_mntpt.empty()) {
+#ifdef GTEST_SKIP
+    GTEST_SKIP() << "Host not running cgroup2";
+#else
+    // GTEST_SKIP() is in gtest 1.9.x (note: starting at 1.9.x,
+    // gtest is living at master) and it's unlikely that it will
+    // ever get packaged.
+    OLOG << "Host not running cgroup2";
+    return;
+#endif
+  }
+
+  if (cgroup2fs_mntpt == "/sys/fs/cgroup/unified/") {
+    // If we have the cgroup tree in "hybrid" mode, this will fail when we test
+    // to get the cgroup context, since we will not find any memory stat files
+    // in that tree. Let's also skip this test in that case.
+    // TODO: A better approach would be to find which controllers are mounted in
+    // the cgroup2 mountpoint, but for now this should be enough to get us to
+    // pass our tests on Travis-CI.
+#ifdef GTEST_SKIP
+    GTEST_SKIP() << "This test does not support hybrid hierarchy";
+#else
+    OLOG << "This test does not support hybrid hierarchy";
+    return;
+#endif
+  }
+
+  OomdContext ctx;
+  auto cgroup_ctx = ctx.addToCacheAndGet(CgroupPath(cgroup2fs_mntpt, "/"));
+  ASSERT_TRUE(cgroup_ctx);
+  // If we're running the test, I should hope the root host is using memory
+  // otherwise we've really stumbled onto a competitive advantage.
+  EXPECT_GT(cgroup_ctx->get().current_usage(), 0);
+}
+
+TEST_F(CgroupContextTest, MemoryProtection) {
+  F::materialize(F::makeDir(
+      tempDir_,
+      {F::makeDir(
+          "A",
+          {F::makeFile("memory.current", "10000\n"),
+           F::makeFile("memory.low", "2000\n"),
+           F::makeFile("memory.min", "2500\n"),
+           F::makeDir(
+               "B",
+               {F::makeFile("memory.current", "1000\n"),
+                F::makeFile("memory.low", "250\n"),
+                F::makeFile("memory.min", "200\n"),
+                F::makeDir(
+                    "C",
+                    {F::makeFile("memory.current", "0\n"),
+                     F::makeFile("memory.low", "250\n"),
+                     F::makeFile("memory.min", "200\n")}),
+                F::makeDir(
+                    "D",
+                    {F::makeFile("memory.current", "1000\n"),
+                     F::makeFile("memory.low", "0\n"),
+                     F::makeFile("memory.min", "0\n")})}),
+           F::makeDir(
+               "E",
+               {F::makeFile("memory.current", "250\n"),
+                F::makeFile("memory.low", "1000\n"),
+                F::makeFile("memory.min", "200\n"),
+                F::makeDir(
+                    "F",
+                    {F::makeFile("memory.current", "2000\n"),
+                     F::makeFile("memory.low", "2000\n"),
+                     F::makeFile("memory.min", "2000\n")}),
+                F::makeDir(
+                    "G",
+                    {F::makeFile("memory.current", "3000\n"),
+                     F::makeFile("memory.low", "3000\n"),
+                     F::makeFile("memory.min", "3000\n")})})})}));
+
+  // Top level slice gets whatever protection it claims
+  auto cgroup_ctx = ctx_.addToCacheAndGet(CgroupPath(tempDir_, "A"));
+  ASSERT_TRUE(cgroup_ctx);
+  EXPECT_EQ(cgroup_ctx->get().memory_protection(), 2500);
+
+  // If sum of sibling protection is less than parent protection, all get
+  // whatever they claim
+  cgroup_ctx = ctx_.addToCacheAndGet(CgroupPath(tempDir_, "A/B"));
+  ASSERT_TRUE(cgroup_ctx);
+  EXPECT_EQ(cgroup_ctx->get().memory_protection(), 250);
+  cgroup_ctx = ctx_.addToCacheAndGet(CgroupPath(tempDir_, "A/E"));
+  ASSERT_TRUE(cgroup_ctx);
+  EXPECT_EQ(cgroup_ctx->get().memory_protection(), 250);
+
+  // If sum of sibling protection is zero, all get zero
+  cgroup_ctx = ctx_.addToCacheAndGet(CgroupPath(tempDir_, "A/B/C"));
+  ASSERT_TRUE(cgroup_ctx);
+  EXPECT_EQ(cgroup_ctx->get().memory_protection(), 0);
+  cgroup_ctx = ctx_.addToCacheAndGet(CgroupPath(tempDir_, "A/B/D"));
+  ASSERT_TRUE(cgroup_ctx);
+  EXPECT_EQ(cgroup_ctx->get().memory_protection(), 0);
+
+  // If sum of sibling protection exceeds parent protection, split in proportion
+  cgroup_ctx = ctx_.addToCacheAndGet(CgroupPath(tempDir_, "A/E/F"));
+  ASSERT_TRUE(cgroup_ctx);
+  EXPECT_EQ(cgroup_ctx->get().memory_protection(), 100);
+  cgroup_ctx = ctx_.addToCacheAndGet(CgroupPath(tempDir_, "A/E/G"));
+  ASSERT_TRUE(cgroup_ctx);
+  EXPECT_EQ(cgroup_ctx->get().memory_protection(), 150);
+}
+
+/*
+ * Verify that CgroupContext won't read from a recreated cgroup.
+ */
+TEST_F(CgroupContextTest, DistinguishRecreate) {
+  F::materialize(F::makeDir(
+      tempDir_,
+      {F::makeDir("system.slice", {F::makeFile("memory.current", "123\n")})}));
+
+  auto cgroup_ctx = ctx_.addToCacheAndGet(CgroupPath(tempDir_, "system.slice"));
+  ASSERT_TRUE(cgroup_ctx);
+  ASSERT_EQ(cgroup_ctx->get().current_usage(), 123);
+
+  // Remove cgroup and recreate one with the exact same name
+  F::rmrChecked(tempDir_ + "/system.slice");
+  F::materialize(F::makeDir(
+      tempDir_,
+      {F::makeDir("system.slice", {F::makeFile("memory.current", "234\n")})}));
+
+  ctx_.refresh();
+  // With real cgroup the CgroupContext should already be invalid, but with mock
+  // fs, the dir fd is still open (fstat ok). Either way, files under it won't
+  // be accessible, and all reads should returns nullopt and set error to
+  // INVALID_CGROUP.
+  auto err = NewCgroupContext::Error::NO_ERROR;
+  EXPECT_EQ(cgroup_ctx->get().current_usage(&err), std::nullopt);
+  EXPECT_EQ(err, NewCgroupContext::Error::INVALID_CGROUP);
+}
+
+/*
+ * Verify expected values are read from fs.
+ * Verify data are cached and not affected by fs changes.
+ * Verify fs changes are reflected once refresh() is called.
+ */
+TEST_F(CgroupContextTest, DataLifeCycle) {
+  // Set up cgroup control files
+  F::materialize(F::makeDir(
+      tempDir_,
+      {F::makeDir(
+          "system.slice",
+          {F::makeFile(
+               "cgroup.stat",
+               {"nr_descendants 2\n"
+                "nr_dying_descendants 1\n"}),
+           F::makeFile(
+               "io.pressure",
+               {"some avg10=0.04 avg60=0.03 avg300=0.02 total=12345\n"
+                "full avg10=0.03 avg60=0.02 avg300=0.01 total=23456\n"}),
+           F::makeFile(
+               "io.stat",
+               {"1:10"
+                " rbytes=1111111 wbytes=2222222 rios=33 wios=44"
+                " dbytes=5555555555 dios=6\n"
+                "1:11"
+                " rbytes=2222222 wbytes=3333333 rios=44 wios=55"
+                " dbytes=6666666666 dios=7\n"}),
+           F::makeFile("memory.current", {"1122334455\n"}),
+           F::makeFile("memory.high", {"2233445566\n"}),
+           F::makeFile("memory.high.tmp", {"max 0\n"}),
+           F::makeFile("memory.low", {"11223344\n"}),
+           F::makeFile("memory.max", {"3344556677\n"}),
+           F::makeFile("memory.min", {"112233\n"}),
+           F::makeFile(
+               "memory.pressure",
+               {"some avg10=0.31 avg60=0.21 avg300=0.11 total=1234567\n"
+                "full avg10=0.30 avg60=0.20 avg300=0.10 total=2345678\n"}),
+           F::makeFile(
+               "memory.stat",
+               {"anon 123456789\n"
+                "file 12345678\n"}),
+           F::makeFile("memory.swap.current", {"1234\n"}),
+           F::makeDir("service1.service", {}),
+           F::makeDir("service2.service", {}),
+           F::makeDir("service3.service", {})})}));
+
+  auto cgroup_ctx_opt =
+      ctx_.addToCacheAndGet(CgroupPath(tempDir_, "system.slice"));
+  ASSERT_TRUE(cgroup_ctx_opt);
+  const auto& cgroup_ctx = cgroup_ctx_opt->get();
+
+  std::decay_t<decltype(cgroup_ctx.children())> children;
+  std::decay_t<decltype(cgroup_ctx.mem_pressure())> mem_pressure;
+  std::decay_t<decltype(cgroup_ctx.io_pressure())> io_pressure;
+  std::decay_t<decltype(cgroup_ctx.memory_stat())> memory_stat;
+  std::decay_t<decltype(cgroup_ctx.io_stat())> io_stat;
+  decltype(cgroup_ctx.current_usage()) current_usage;
+  decltype(cgroup_ctx.swap_usage()) swap_usage;
+  decltype(cgroup_ctx.memory_low()) memory_low;
+  decltype(cgroup_ctx.memory_min()) memory_min;
+  decltype(cgroup_ctx.memory_high()) memory_high;
+  decltype(cgroup_ctx.memory_high_tmp()) memory_high_tmp;
+  decltype(cgroup_ctx.memory_max()) memory_max;
+  decltype(cgroup_ctx.nr_dying_descendants()) nr_dying_descendants;
+  decltype(cgroup_ctx.memory_protection()) memory_protection;
+  decltype(cgroup_ctx.io_cost_cumulative()) io_cost_cumulative;
+  decltype(cgroup_ctx.average_usage()) average_usage;
+  decltype(cgroup_ctx.io_cost_rate()) io_cost_rate;
+
+  auto set_and_check_fields = [&]() {
+    children = cgroup_ctx.children();
+    mem_pressure = cgroup_ctx.mem_pressure();
+    io_pressure = cgroup_ctx.io_pressure();
+    memory_stat = cgroup_ctx.memory_stat();
+    io_stat = cgroup_ctx.io_stat();
+    current_usage = cgroup_ctx.current_usage();
+    swap_usage = cgroup_ctx.swap_usage();
+    memory_low = cgroup_ctx.memory_low();
+    memory_min = cgroup_ctx.memory_min();
+    memory_high = cgroup_ctx.memory_high();
+    memory_high_tmp = cgroup_ctx.memory_high_tmp();
+    memory_max = cgroup_ctx.memory_max();
+    nr_dying_descendants = cgroup_ctx.nr_dying_descendants();
+    memory_protection = cgroup_ctx.memory_protection();
+    io_cost_cumulative = cgroup_ctx.io_cost_cumulative();
+    average_usage = cgroup_ctx.average_usage();
+    io_cost_rate = cgroup_ctx.io_cost_rate();
+
+    ASSERT_TRUE(children);
+    ASSERT_TRUE(mem_pressure);
+    ASSERT_TRUE(io_pressure);
+    ASSERT_TRUE(memory_stat);
+    ASSERT_TRUE(io_stat);
+    ASSERT_TRUE(current_usage);
+    ASSERT_TRUE(swap_usage);
+    ASSERT_TRUE(memory_low);
+    ASSERT_TRUE(memory_min);
+    ASSERT_TRUE(memory_high);
+    ASSERT_TRUE(memory_high_tmp);
+    ASSERT_TRUE(memory_max);
+    ASSERT_TRUE(nr_dying_descendants);
+    ASSERT_TRUE(memory_protection);
+    ASSERT_TRUE(io_cost_cumulative);
+    ASSERT_TRUE(average_usage);
+    ASSERT_TRUE(io_cost_rate);
+  };
+
+  set_and_check_fields();
+
+  using memory_stat_t = decltype(memory_stat);
+
+  // Check basic readings
+  EXPECT_THAT(
+      *children,
+      UnorderedElementsAre(
+          "service1.service", "service2.service", "service3.service"));
+  EXPECT_FLOAT_EQ(mem_pressure->sec_10, 0.3);
+  EXPECT_FLOAT_EQ(mem_pressure->sec_60, 0.2);
+  EXPECT_FLOAT_EQ(mem_pressure->sec_300, 0.1);
+  EXPECT_EQ(
+      mem_pressure->total, std::optional<std::chrono::microseconds>(2345678));
+  EXPECT_FLOAT_EQ(io_pressure->sec_10, 0.03);
+  EXPECT_FLOAT_EQ(io_pressure->sec_60, 0.02);
+  EXPECT_FLOAT_EQ(io_pressure->sec_300, 0.01);
+  EXPECT_EQ(
+      io_pressure->total, std::optional<std::chrono::microseconds>(23456));
+  EXPECT_EQ(
+      memory_stat, memory_stat_t({{"anon", 123456789}, {"file", 12345678}}));
+  EXPECT_EQ(
+      io_stat,
+      IOStat({{"1:10", 1111111, 2222222, 33, 44, 5555555555, 6},
+              {"1:11", 2222222, 3333333, 44, 55, 6666666666, 7}}));
+  EXPECT_EQ(current_usage, 1122334455);
+  EXPECT_EQ(swap_usage, 1234);
+  EXPECT_EQ(memory_low, 11223344);
+  EXPECT_EQ(memory_min, 112233);
+  EXPECT_EQ(memory_high, 2233445566);
+  EXPECT_EQ(memory_high_tmp, std::numeric_limits<int64_t>::max());
+  EXPECT_EQ(memory_max, 3344556677);
+  EXPECT_EQ(nr_dying_descendants, 1);
+  EXPECT_EQ(memory_protection, 11223344);
+  // int64_t(1122334455 / 4.0)
+  EXPECT_EQ(average_usage, 280583613);
+  // 1111111*5 + 2222222*3 + 33*6 + 44*4 + 5555555555*1 + 6*2 +
+  // 2222222*2 + 3333333*4 + 44*1 + 55*3 + 6666666666*6 + 7*5
+  EXPECT_EQ(io_cost_cumulative, 45585556178);
+  EXPECT_EQ(io_cost_rate, 0);
+
+  // Update most of control files (by adding 1, 0.1 or 0.01)
+  F::materialize(F::makeDir(
+      tempDir_,
+      {F::makeDir(
+          "system.slice",
+          {F::makeFile(
+               "cgroup.stat",
+               {"nr_descendants 3\n"
+                "nr_dying_descendants 2\n"}),
+           F::makeFile(
+               "io.pressure",
+               {"some avg10=0.04 avg60=0.03 avg300=0.02 total=12346\n"
+                "full avg10=0.04 avg60=0.03 avg300=0.02 total=23457\n"}),
+           F::makeFile(
+               "io.stat",
+               {"1:10"
+                " rbytes=1111112 wbytes=2222223 rios=34 wios=45"
+                " dbytes=5555555556 dios=7\n"
+                "1:11"
+                " rbytes=2222223 wbytes=3333334 rios=45 wios=56"
+                " dbytes=6666666667 dios=8\n"}),
+           F::makeFile("memory.current", {"1122334456\n"}),
+           F::makeFile("memory.high", {"2233445567\n"}),
+           F::makeFile("memory.high.tmp", {"max 0\n"}),
+           F::makeFile("memory.low", {"11223345\n"}),
+           F::makeFile("memory.min", {"112234\n"}),
+           F::makeFile("memory.max", {"3344556678\n"}),
+           F::makeFile(
+               "memory.pressure",
+               {"some avg10=0.31 avg60=0.21 avg300=0.11 total=1234568\n"
+                "full avg10=0.31 avg60=0.21 avg300=0.11 total=2345679\n"}),
+           F::makeFile(
+               "memory.stat",
+               {"anon 123456790\n"
+                "file 12345679\n"}),
+           F::makeFile("memory.swap.current", {"1235\n"}),
+           F::makeDir("service1.service", {}),
+           F::makeDir("service2.service", {}),
+           F::makeDir("service3.service", {}),
+           F::makeDir("service4.service", {})})}));
+  F::rmrChecked(tempDir_ + "/system.slice/service2.service");
+
+  // All values should stay the same
+  EXPECT_EQ(cgroup_ctx.children(), children);
+  EXPECT_EQ(cgroup_ctx.mem_pressure(), mem_pressure);
+  EXPECT_EQ(cgroup_ctx.io_pressure(), io_pressure);
+  EXPECT_EQ(cgroup_ctx.memory_stat(), memory_stat);
+  EXPECT_EQ(cgroup_ctx.io_stat(), io_stat);
+  EXPECT_EQ(cgroup_ctx.current_usage(), current_usage);
+  EXPECT_EQ(cgroup_ctx.swap_usage(), swap_usage);
+  EXPECT_EQ(cgroup_ctx.memory_low(), memory_low);
+  EXPECT_EQ(cgroup_ctx.memory_min(), memory_min);
+  EXPECT_EQ(cgroup_ctx.memory_high(), memory_high);
+  EXPECT_EQ(cgroup_ctx.memory_high_tmp(), memory_high_tmp);
+  EXPECT_EQ(cgroup_ctx.memory_max(), memory_max);
+  EXPECT_EQ(cgroup_ctx.nr_dying_descendants(), nr_dying_descendants);
+  EXPECT_EQ(cgroup_ctx.memory_protection(), memory_protection);
+  EXPECT_EQ(cgroup_ctx.average_usage(), average_usage);
+  EXPECT_EQ(cgroup_ctx.io_cost_cumulative(), io_cost_cumulative);
+  EXPECT_EQ(cgroup_ctx.io_cost_rate(), io_cost_rate);
+
+  // Call refresh() to clear cache and retrieve values again
+  ctx_.refresh();
+  set_and_check_fields();
+
+  // Data are now updated
+  EXPECT_THAT(
+      *children,
+      UnorderedElementsAre(
+          "service1.service", "service3.service", "service4.service"));
+  EXPECT_FLOAT_EQ(mem_pressure->sec_10, 0.31);
+  EXPECT_FLOAT_EQ(mem_pressure->sec_60, 0.21);
+  EXPECT_FLOAT_EQ(mem_pressure->sec_300, 0.11);
+  EXPECT_EQ(
+      mem_pressure->total, std::optional<std::chrono::microseconds>(2345679));
+  EXPECT_FLOAT_EQ(io_pressure->sec_10, 0.04);
+  EXPECT_FLOAT_EQ(io_pressure->sec_60, 0.03);
+  EXPECT_FLOAT_EQ(io_pressure->sec_300, 0.02);
+  EXPECT_EQ(
+      io_pressure->total, std::optional<std::chrono::microseconds>(23457));
+  EXPECT_EQ(
+      memory_stat, memory_stat_t({{"anon", 123456790}, {"file", 12345679}}));
+  EXPECT_EQ(
+      io_stat,
+      IOStat({{"1:10", 1111112, 2222223, 34, 45, 5555555556, 7},
+              {"1:11", 2222223, 3333334, 45, 56, 6666666667, 8}}));
+  EXPECT_EQ(current_usage, 1122334456);
+  EXPECT_EQ(swap_usage, 1235);
+  EXPECT_EQ(memory_low, 11223345);
+  EXPECT_EQ(memory_min, 112234);
+  EXPECT_EQ(memory_high, 2233445567);
+  EXPECT_EQ(memory_high_tmp, std::numeric_limits<int64_t>::max());
+  EXPECT_EQ(memory_max, 3344556678);
+  EXPECT_EQ(nr_dying_descendants, 2);
+  EXPECT_EQ(memory_protection, 11223345);
+  // itn64_t(280583613 * (3.0 / 4.0) + 1122334456 / 4.0)
+  EXPECT_EQ(average_usage, 491021323);
+  // 1111112*5 + 2222223*3 + 34*6 + 45*4 + 5555555556*1 + 7*2 +
+  // 2222223*2 + 3333334*4 + 45*1 + 56*3 + 6666666667*6 + 8*5
+  EXPECT_EQ(io_cost_cumulative, 45585556220);
+  EXPECT_EQ(io_cost_rate, 45585556220 - 45585556178);
+}

--- a/src/oomd/NewOomdContext.cpp
+++ b/src/oomd/NewOomdContext.cpp
@@ -1,0 +1,153 @@
+/*
+ * Copyright (C) 2018-present, Facebook, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include "oomd/NewOomdContext.h"
+
+#include "oomd/Log.h"
+#include "oomd/util/Fs.h"
+
+namespace Oomd {
+
+std::vector<CgroupPath> OomdContext::cgroups() const {
+  std::vector<CgroupPath> keys;
+
+  for (const auto& pair : cgroups_) {
+    keys.emplace_back(pair.first);
+  }
+
+  return keys;
+}
+
+std::optional<OomdContext::ConstCgroupContextRef> OomdContext::addToCacheAndGet(
+    const CgroupPath& cgroup) {
+  // Return cached cgroup if already exists
+  if (auto pos = cgroups_.find(cgroup); pos != cgroups_.end()) {
+    return pos->second;
+  }
+  auto ctx = NewCgroupContext(*this, cgroup);
+  if (!ctx.isValid()) {
+    return std::nullopt;
+  }
+  return cgroups_.emplace(cgroup, std::move(ctx)).first->second;
+}
+
+std::vector<OomdContext::ConstCgroupContextRef> OomdContext::addToCacheAndGet(
+    const std::unordered_set<CgroupPath>& cgroups) {
+  std::unordered_set<CgroupPath> all_resolved;
+  std::vector<ConstCgroupContextRef> ret;
+  for (const auto& cgroup : cgroups) {
+    auto resolved = cgroup.resolveWildcard();
+    all_resolved.insert(resolved.begin(), resolved.end());
+  }
+  for (const auto& resolved : all_resolved) {
+    if (auto cgroup_ctx = addToCacheAndGet(resolved)) {
+      ret.push_back(*cgroup_ctx);
+    }
+  }
+  return ret;
+}
+
+const ActionContext& OomdContext::getActionContext() const {
+  return action_context_;
+}
+
+void OomdContext::setActionContext(const ActionContext& context) {
+  action_context_ = context;
+}
+
+const SystemContext& OomdContext::getSystemContext() const {
+  return system_ctx_;
+}
+
+void OomdContext::setSystemContext(const SystemContext& context) {
+  system_ctx_ = context;
+}
+
+void OomdContext::dump() {
+  std::vector<ConstCgroupContextRef> cgroups;
+  for (auto& pair : cgroups_) {
+    cgroups.push_back(pair.second);
+  }
+  dump(cgroups);
+}
+
+void OomdContext::dump(
+    const std::vector<ConstCgroupContextRef>& cgroup_ctxs,
+    const bool skip_negligible) {
+  auto cgmax = std::numeric_limits<int64_t>::max();
+  OLOG << "Dumping OomdContext: ";
+  for (const CgroupContext& cgroup_ctx : cgroup_ctxs) {
+    auto mem_pressure = cgroup_ctx.mem_pressure().value_or(ResourcePressure{});
+    auto io_pressure = cgroup_ctx.io_pressure().value_or(ResourcePressure{});
+    auto current_usage = cgroup_ctx.current_usage().value_or(0);
+    auto average_usage = cgroup_ctx.average_usage().value_or(0);
+    auto memory_low = cgroup_ctx.memory_low().value_or(0);
+    auto memory_min = cgroup_ctx.memory_min().value_or(0);
+    auto memory_high = cgroup_ctx.memory_high().value_or(cgmax);
+    auto memory_high_tmp = cgroup_ctx.memory_high_tmp().value_or(cgmax);
+    auto memory_max = cgroup_ctx.memory_max().value_or(cgmax);
+    auto memory_protection = cgroup_ctx.memory_protection().value_or(0);
+    auto anon_usage = cgroup_ctx.anon_usage().value_or(0);
+    auto swap_usage = cgroup_ctx.swap_usage().value_or(0);
+    auto io_cost_cumulative = cgroup_ctx.io_cost_cumulative().value_or(0);
+    auto io_cost_rate = cgroup_ctx.io_cost_rate().value_or(0);
+
+    if (skip_negligible) {
+      // don't show if <1% pressure && <.1% usage
+      auto meminfo = Fs::getMeminfo();
+      const float press_min = 1;
+      const int64_t mem_min = meminfo["MemTotal"] / 1000;
+      const int64_t swap_min = meminfo["SwapTotal"] / 1000;
+
+      if (!(mem_pressure.sec_10 >= press_min ||
+            mem_pressure.sec_60 >= press_min ||
+            mem_pressure.sec_300 >= press_min ||
+            io_pressure.sec_10 >= press_min ||
+            io_pressure.sec_60 >= press_min ||
+            io_pressure.sec_300 >= press_min || current_usage > mem_min ||
+            average_usage > mem_min || swap_usage > swap_min)) {
+        continue;
+      }
+    }
+
+    OLOG << "name=" << cgroup_ctx.cgroup().relativePath();
+    OLOG << "  pressure=" << mem_pressure.sec_10 << ":" << mem_pressure.sec_60
+         << ":" << mem_pressure.sec_300 << "-" << io_pressure.sec_10 << ":"
+         << io_pressure.sec_60 << ":" << io_pressure.sec_300;
+    OLOG << "  mem=" << (current_usage >> 20) << "MB"
+         << " mem_avg=" << (average_usage >> 20) << "MB"
+         << " mem_low=" << (memory_low >> 20) << "MB"
+         << " mem_min=" << (memory_min >> 20) << "MB"
+         << " mem_high=" << (memory_high >> 20) << "MB"
+         << " mem_high_tmp=" << (memory_high_tmp >> 20) << "MB"
+         << " mem_max=" << (memory_max >> 20) << "MB"
+         << " mem_prot=" << (memory_protection >> 20) << "MB"
+         << " anon=" << (anon_usage >> 20) << "MB"
+         << " swap_usage=" << (swap_usage >> 20) << "MB";
+    OLOG << "  io_cost_cumulative=" << io_cost_cumulative
+         << " io_cost_rate=" << io_cost_rate;
+  }
+}
+
+void OomdContext::refresh() {
+  auto it = cgroups_.begin();
+  while (it != cgroups_.end()) {
+    it = it->second.refresh() ? std::next(it) : cgroups_.erase(it);
+  }
+}
+
+} // namespace Oomd

--- a/src/oomd/NewOomdContext.h
+++ b/src/oomd/NewOomdContext.h
@@ -1,0 +1,136 @@
+/*
+ * Copyright (C) 2018-present, Facebook, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#pragma once
+
+#include <algorithm>
+#include <functional>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+#include "oomd/CgroupContext.h"
+#include "oomd/include/CgroupPath.h"
+#include "oomd/include/Types.h"
+
+namespace Oomd {
+
+struct ActionContext {
+  std::string ruleset;
+  std::string detectorgroup;
+};
+
+struct ContextParams {
+  // TODO(dlxu): migrate to ring buffer for raw datapoints so plugins
+  // can calculate weighted average themselves
+  double average_size_decay{4.0};
+  // root io device IDs (<major>:<minor>) and their device types (SSD/HDD)
+  std::unordered_map<std::string, DeviceType> io_devs;
+  IOCostCoeffs hdd_coeffs;
+  IOCostCoeffs ssd_coeffs;
+};
+
+class OomdContext {
+ public:
+  // Avoid name collision with CgroupContext in Types.h
+  using CgroupContext = Oomd::NewCgroupContext;
+
+  // Immutable CgroupContext type returned from public APIs, which has life time
+  // valid for the interval being accessed. Plugins should never store it.
+  using ConstCgroupContextRef = std::reference_wrapper<const CgroupContext>;
+
+  explicit OomdContext(const ContextParams& params = {}) : params_(params) {}
+  ~OomdContext() = default;
+  OomdContext(OomdContext&& other) noexcept = default;
+  OomdContext& operator=(OomdContext&& other) = default;
+
+  std::vector<CgroupPath> cgroups() const;
+
+  const ContextParams& getParams() const {
+    return params_;
+  }
+
+  /*
+   * Add a cgroup to cache if not already exist, and return the result. If it's
+   * invalid, return std::nullopt.
+   */
+  std::optional<ConstCgroupContextRef> addToCacheAndGet(
+      const CgroupPath& cgroup);
+
+  /*
+   * Add a set of cgroups to cache if not already exist, and return the result.
+   * Cgroup paths may contain glob pattern, which will be expanded if valid.
+   * Returned CgroupContexts are all valid and won't contain duplicate.
+   */
+  std::vector<ConstCgroupContextRef> addToCacheAndGet(
+      const std::unordered_set<CgroupPath>& cgroups);
+
+  /*
+   * Add a set of cgroups to cache, and return the resulting CgroupContext
+   * sorting in descending order by the get_key functor, which accepts two const
+   * reference of CgroupContext and returns something comparable.
+   */
+  template <class Functor>
+  std::vector<ConstCgroupContextRef> reverseSort(
+      const std::unordered_set<CgroupPath>& cgroups,
+      Functor&& get_key) {
+    auto sorted = addToCacheAndGet(cgroups);
+    std::sort(sorted.begin(), sorted.end(), [&](const auto& a, const auto& b) {
+      return get_key(a.get()) > get_key(b.get());
+    });
+    return sorted;
+  }
+
+  /*
+   * Dumps OomdContext state to stderr
+   */
+  void dump();
+  static void dump(
+      const std::vector<ConstCgroupContextRef>& vec,
+      const bool skip_negligible = false);
+
+  /*
+   * Used to let action plugins know which ruleset and detector group
+   * triggered it
+   */
+  const ActionContext& getActionContext() const;
+  void setActionContext(const ActionContext& context);
+
+  /*
+   * Used to let action plugins retrieve and set info stored in struct
+   */
+  const SystemContext& getSystemContext() const;
+  void setSystemContext(const SystemContext& context);
+
+  /*
+   * Refresh all cgroups and remove ones no longer exist.
+   */
+  void refresh();
+
+ private:
+  // Test only
+  friend class TestHelper;
+
+  struct ContextParams params_;
+  std::unordered_map<CgroupPath, CgroupContext> cgroups_;
+  ActionContext action_context_;
+  SystemContext system_ctx_;
+};
+
+} // namespace Oomd

--- a/src/oomd/NewOomdContextTest.cpp
+++ b/src/oomd/NewOomdContextTest.cpp
@@ -1,0 +1,173 @@
+/*
+ * Copyright (C) 2018-present, Facebook, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "oomd/NewOomdContext.h"
+#include "oomd/util/Fixture.h"
+#include "oomd/util/TestHelper.h"
+
+using namespace Oomd;
+using namespace testing;
+
+class OomdContextTest : public ::testing::Test {
+ public:
+  OomdContextTest() = default;
+  OomdContext ctx;
+
+ protected:
+  using F = Fixture;
+  void SetUp() override {
+    tempdir_ = F::mkdtempChecked();
+  }
+  void TearDown() override {
+    F::rmrChecked(tempdir_);
+  }
+  std::string tempdir_;
+};
+
+namespace std {
+// Check if two reference_wrappers are exactly the same
+bool operator==(
+    const OomdContext::ConstCgroupContextRef& lhs,
+    const OomdContext::ConstCgroupContextRef& rhs) {
+  return std::addressof(lhs.get()) == std::addressof(rhs.get());
+};
+} // namespace std
+
+TEST_F(OomdContextTest, MoveConstructor) {
+  CgroupPath path(tempdir_, "asdf");
+  EXPECT_FALSE(ctx.addToCacheAndGet(path));
+  OomdContext other;
+  TestHelper::setCgroupData(
+      other,
+      path,
+      TestHelper::CgroupData{
+          .current_usage = 1, .memory_low = 2, .average_usage = 3});
+
+  ctx = std::move(other);
+  F::materialize(F::makeDir(tempdir_, {F::makeDir("asdf")}));
+
+  ASSERT_THAT(ctx.cgroups(), ElementsAre(path));
+  auto moved_cgroup_ctx = ctx.addToCacheAndGet(path);
+  ASSERT_TRUE(moved_cgroup_ctx);
+  EXPECT_EQ(moved_cgroup_ctx->get().current_usage(), 1);
+  EXPECT_EQ(moved_cgroup_ctx->get().memory_low(), 2);
+  EXPECT_EQ(moved_cgroup_ctx->get().average_usage(), 3);
+}
+
+TEST_F(OomdContextTest, CgroupKeys) {
+  F::materialize(F::makeDir(tempdir_, {F::makeDir("asdf"), F::makeDir("wow")}));
+  CgroupPath p1(tempdir_, "asdf");
+  CgroupPath p2(tempdir_, "wow");
+
+  EXPECT_EQ(ctx.cgroups().size(), 0);
+  EXPECT_TRUE(ctx.addToCacheAndGet(p1));
+  EXPECT_TRUE(ctx.addToCacheAndGet(p2));
+  EXPECT_THAT(ctx.cgroups(), UnorderedElementsAre(p1, p2));
+}
+
+TEST_F(OomdContextTest, CgroupKeyRoot) {
+  CgroupPath root(tempdir_, "/");
+  EXPECT_TRUE(ctx.addToCacheAndGet(root));
+  EXPECT_THAT(ctx.cgroups(), ElementsAre(root));
+}
+
+TEST_F(OomdContextTest, GetMultiple) {
+  F::materialize(F::makeDir(
+      tempdir_,
+      {F::makeDir("dir1"),
+       F::makeDir("dir2"),
+       F::makeDir("dir3"),
+       F::makeFile("file1")}));
+  CgroupPath p1(tempdir_, "dir1");
+  CgroupPath p2(tempdir_, "dir2");
+  CgroupPath p3(tempdir_, "dir3");
+  CgroupPath p4(tempdir_, "file1");
+  CgroupPath p5(tempdir_, "NOT_EXIST");
+
+  auto cgroups = ctx.addToCacheAndGet({p1, p2, p3, p4, p5});
+  auto cg1 = ctx.addToCacheAndGet(p1);
+  auto cg2 = ctx.addToCacheAndGet(p2);
+  auto cg3 = ctx.addToCacheAndGet(p3);
+  ASSERT_TRUE(cg1);
+  ASSERT_TRUE(cg2);
+  ASSERT_TRUE(cg3);
+  EXPECT_THAT(cgroups, UnorderedElementsAre(*cg1, *cg2, *cg3));
+
+  CgroupPath p6(tempdir_, "*");
+  EXPECT_THAT(
+      ctx.addToCacheAndGet(std::unordered_set<CgroupPath>{p6}),
+      UnorderedElementsAreArray(cgroups));
+  // Check no duplicates
+  EXPECT_THAT(
+      ctx.addToCacheAndGet({p1, p2, p3, p4, p5, p6}),
+      UnorderedElementsAreArray(cgroups));
+  // Check empty result
+  EXPECT_EQ(ctx.addToCacheAndGet({p4, p5}).size(), 0);
+  EXPECT_EQ(ctx.addToCacheAndGet({}).size(), 0);
+}
+
+TEST_F(OomdContextTest, SortContext) {
+  F::materialize(F::makeDir(
+      tempdir_,
+      {F::makeDir(
+           "biggest",
+           {F::makeFile("memory.current", "99999999\n"),
+            F::makeFile("memory.low", "1\n")}),
+       F::makeDir(
+           "smallest",
+           {F::makeFile("memory.current", "1\n"),
+            F::makeFile("memory.low", "4\n")}),
+       F::makeDir(
+           "asdf",
+           {F::makeFile("memory.current", "88888888\n"),
+            F::makeFile("memory.low", "2\n")}),
+       F::makeDir(
+           "fdsa",
+           {F::makeFile("memory.current", "77777777\n"),
+            F::makeFile("memory.low", "3\n")})}));
+  CgroupPath p1(tempdir_, "biggest");
+  CgroupPath p2(tempdir_, "smallest");
+  CgroupPath p3(tempdir_, "asdf");
+  CgroupPath p4(tempdir_, "fdsa");
+
+  auto sorted = ctx.reverseSort({p1, p2, p3, p4}, [](const auto& cgroup_ctx) {
+    return cgroup_ctx.current_usage().value_or(0);
+  });
+
+  auto cg1 = ctx.addToCacheAndGet(p1);
+  auto cg2 = ctx.addToCacheAndGet(p2);
+  auto cg3 = ctx.addToCacheAndGet(p3);
+  auto cg4 = ctx.addToCacheAndGet(p4);
+  ASSERT_TRUE(cg1);
+  ASSERT_TRUE(cg2);
+  ASSERT_TRUE(cg3);
+  ASSERT_TRUE(cg4);
+
+  EXPECT_THAT(sorted, ElementsAre(*cg1, *cg3, *cg4, *cg2));
+
+  CgroupPath p5(tempdir_, "*est");
+  CgroupPath p6(tempdir_, "{biggest,smallest,asdf,fdsa}");
+  CgroupPath p7(tempdir_, "NOT_EXIST");
+  sorted = ctx.reverseSort({p5, p6, p7}, [](const auto& cgroup_ctx) {
+    return cgroup_ctx.memory_low().value_or(0);
+  });
+
+  EXPECT_THAT(sorted, ElementsAre(*cg2, *cg4, *cg3, *cg1));
+}

--- a/src/oomd/include/Types.h
+++ b/src/oomd/include/Types.h
@@ -41,6 +41,12 @@ struct DeviceIOStat {
   int64_t wios{0};
   int64_t dbytes{0};
   int64_t dios{0};
+
+  bool operator==(const DeviceIOStat& rhs) const {
+    return dev_id == rhs.dev_id && rbytes == rhs.rbytes &&
+        wbytes == rhs.wbytes && rios == rhs.rios && wios == rhs.wios &&
+        dbytes == rhs.dbytes && dios == rhs.dios;
+  }
 };
 
 using IOStat = std::vector<DeviceIOStat>;
@@ -59,6 +65,11 @@ struct ResourcePressure {
   float sec_60{0};
   float sec_300{0};
   std::optional<std::chrono::microseconds> total{std::nullopt};
+
+  bool operator==(const ResourcePressure& rhs) const {
+    return sec_10 == rhs.sec_10 && sec_60 == rhs.sec_60 &&
+        sec_300 == rhs.sec_300 && total == rhs.total;
+  }
 };
 
 // If you update this class with something that could be valuable to know

--- a/src/oomd/util/Fixture.h
+++ b/src/oomd/util/Fixture.h
@@ -56,6 +56,11 @@ class Fixture {
   static DirEntryPair makeDir(
       const std::string& name,
       std::unordered_map<std::string, DirEntry> entries = {});
+  static void materialize(
+      const DirEntryPair& pair,
+      const std::string& path = "") {
+    pair.second.materialize(path, pair.first);
+  }
 
   // utility functions that interact with file system
   static std::string mkdtempChecked();

--- a/src/oomd/util/FsTest.cpp
+++ b/src/oomd/util/FsTest.cpp
@@ -48,18 +48,6 @@ class FsTest : public ::testing::Test {
   FsFixture fixture_{};
 };
 
-namespace Oomd {
-bool operator==(const DeviceIOStat& lhs, const DeviceIOStat& rhs) {
-  return lhs.dev_id == rhs.dev_id && lhs.rbytes == rhs.rbytes &&
-      lhs.wbytes == rhs.wbytes && lhs.rios == rhs.rios &&
-      lhs.wios == rhs.wios && lhs.dbytes == rhs.dbytes && lhs.dios == rhs.dios;
-}
-bool operator==(const ResourcePressure& lhs, const ResourcePressure& rhs) {
-  return lhs.sec_10 == rhs.sec_10 && lhs.sec_60 == rhs.sec_60 &&
-      lhs.sec_300 == rhs.sec_300 && lhs.total == rhs.total;
-}
-} // namespace Oomd
-
 TEST_F(FsTest, FindDirectories) {
   auto dir = fixture_.fsDataDir();
   auto de = Fs::readDir(dir, Fs::DE_DIR);

--- a/src/oomd/util/TestHelper.h
+++ b/src/oomd/util/TestHelper.h
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2019-present, Facebook, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#pragma once
+
+#include "oomd/CgroupContext.h"
+#include "oomd/NewOomdContext.h"
+
+namespace Oomd {
+
+/*
+ * Friend of data classes to access their private fields for test injection.
+ * This class must only be included in tests and not the main binary.
+ */
+class TestHelper {
+ public:
+  using CgroupData = NewCgroupContext::CgroupData;
+
+  static CgroupData& getDataRef(const NewCgroupContext& cgroup_ctx) {
+    return *cgroup_ctx.data_;
+  }
+
+  static std::unordered_map<CgroupPath, NewCgroupContext>& getCgroupsRef(
+      OomdContext& ctx) {
+    return ctx.cgroups_;
+  }
+
+  /*
+   * Set the cgroup data of a CgroupContext in OomdContext.
+   * This is a shortcut for setting up CgroupContext without creating control
+   * file fixtures. However, retrieving CgroupContext from OomdContext via
+   * addToCacheAndGet still requires the requested CgroupPath exists, which
+   * could be done using the Fixture utils.
+   */
+  static void setCgroupData(
+      OomdContext& ctx,
+      const CgroupPath& cgroup,
+      const CgroupData& data) {
+    *ctx.cgroups_.try_emplace(cgroup, ctx, cgroup).first->second.data_ = data;
+  }
+};
+
+} // namespace Oomd


### PR DESCRIPTION
Summary:
Make CgroupContext more powerful such that each of its data field is on-demand. When any field is requested by a plugin, CgroupContext retrieves data from cgroupfs and cache it until end of event loop.

In this way, we don't gather all data of all cgroups at the beginning of the event loop in Oomd.cpp and could save a lot of CPU cycles.

A major catch is that temporal data fields like `average_usage` and `io_cost_rate` won't work without some changes. Plugin depending on them need to call them inside `prerun()` so that they will have meaningful value when needed.

To ensure this calling convention, the first time accessing these temporal counters will throw an exception, which requires plugins to handle it explicitly in `prerun()` instead of failing silently.

This diff does not change existing logic to make review easier. As a result a new version of bare bone `OomdContext` is embedded in `CgroupContext`. In the next diff that applies `CgroupContext` to existing code, the embedded `OomdContext` will be removed.

WIP because tests are still missing. Otherwise implementation is done.

Differential Revision: D21229146

