### PR TITLE
Fix meson build caused by static local variable

### DIFF
--- a/src/oomd/plugins/Senpai.h
+++ b/src/oomd/plugins/Senpai.h
@@ -63,8 +63,14 @@ class Senpai : public Engine::BasePlugin {
     int64_t ticks;
   };
 
+  std::optional<bool> hasMemoryHighTmp(const CgroupContext& cgroup_ctx);
+  std::optional<int64_t> readMemhigh(const CgroupContext& cgroup_ctx);
+  bool writeMemhigh(const CgroupContext& cgroup_ctx, int64_t value);
+
   bool tick(const CgroupContext& cgroup_ctx, CgroupState& state);
   std::optional<CgroupState> initializeCgroup(const CgroupContext& cgroup_ctx);
+
+  std::optional<bool> has_memory_high_tmp_{};
 
   std::unordered_set<CgroupPath> cgroups_;
   std::map<CgroupContext::Id, CgroupState> tracked_cgroups_;


### PR DESCRIPTION
Summary:
Meson tests are failing because Senpai uses a static local variable, and meson runs all tests cases in the same executable. As the result, all test cases share the same static variable.

Move the static variable to the Senpai class so we can friend class the test class to reset it in `SetUp()`.

Differential Revision: D21823597

