### PR TITLE
std::optional<Fd> instead of Fd::isValid

### DIFF
--- a/src/oomd/CgroupContext.h
+++ b/src/oomd/CgroupContext.h
@@ -53,7 +53,9 @@ class CgroupContext {
    * As OomdContext is guaranteed to last longer than CgroupContext, use
    * raw reference instead of smart pointer.
    */
-  CgroupContext(OomdContext& ctx, const CgroupPath& cgroup);
+  static std::optional<CgroupContext> make(
+      OomdContext& ctx,
+      const CgroupPath& cgroup);
 
   /*
    * Check if cgroup still exists and archive current data for temporal
@@ -129,6 +131,11 @@ class CgroupContext {
   std::optional<double> memory_growth(Error* err = nullptr) const;
 
  private:
+  explicit CgroupContext(
+      OomdContext& ctx,
+      const CgroupPath& path,
+      Fs::DirFd&& dirFd);
+
   // Test only
   friend class TestHelper;
 

--- a/src/oomd/CgroupContextTest.cpp
+++ b/src/oomd/CgroupContextTest.cpp
@@ -22,6 +22,7 @@
 #include "oomd/Log.h"
 #include "oomd/OomdContext.h"
 #include "oomd/util/Fixture.h"
+#include "oomd/util/TestHelper.h"
 
 using namespace Oomd;
 using namespace testing;
@@ -195,8 +196,8 @@ TEST_F(CgroupContextTest, DistinguishRecreate) {
           {F::makeFile("cgroup.controllers"),
            F::makeFile("memory.current", "123\n")})}));
 
-  CgroupContext cgroup_ctx(ctx_, CgroupPath(tempDir_, "system.slice"));
-  ASSERT_TRUE(cgroup_ctx.fd().isValid());
+  auto cgroup_ctx = ASSERT_EXISTS(
+      CgroupContext::make(ctx_, CgroupPath(tempDir_, "system.slice")));
   ASSERT_EQ(cgroup_ctx.current_usage(), 123);
 
   // Remove cgroup and recreate one with the exact same name
@@ -265,8 +266,8 @@ TEST_F(CgroupContextTest, DataLifeCycle) {
            F::makeDir("service2.service", {}),
            F::makeDir("service3.service", {})})}));
 
-  CgroupContext cgroup_ctx(ctx_, CgroupPath(tempDir_, "system.slice"));
-  ASSERT_TRUE(cgroup_ctx.fd().isValid());
+  auto cgroup_ctx = ASSERT_EXISTS(
+      CgroupContext::make(ctx_, CgroupPath(tempDir_, "system.slice")));
 
   std::decay_t<decltype(cgroup_ctx.children())> children;
   std::decay_t<decltype(cgroup_ctx.mem_pressure())> mem_pressure;

--- a/src/oomd/OomdContext.cpp
+++ b/src/oomd/OomdContext.cpp
@@ -38,11 +38,10 @@ std::optional<OomdContext::ConstCgroupContextRef> OomdContext::addToCacheAndGet(
   if (auto pos = cgroups_.find(cgroup); pos != cgroups_.end()) {
     return pos->second;
   }
-  auto ctx = CgroupContext(*this, cgroup);
-  if (!ctx.fd().isValid()) {
-    return std::nullopt;
+  if (auto ctx = CgroupContext::make(*this, cgroup)) {
+    return cgroups_.emplace(cgroup, std::move(*ctx)).first->second;
   }
-  return cgroups_.emplace(cgroup, std::move(ctx)).first->second;
+  return std::nullopt;
 }
 
 std::vector<OomdContext::ConstCgroupContextRef> OomdContext::addToCacheAndGet(

--- a/src/oomd/OomdContextTest.cpp
+++ b/src/oomd/OomdContextTest.cpp
@@ -53,6 +53,9 @@ bool operator==(
 TEST_F(OomdContextTest, MoveConstructor) {
   CgroupPath path(tempdir_, "asdf");
   EXPECT_FALSE(ctx.addToCacheAndGet(path));
+
+  F::materialize(F::makeDir(tempdir_, {F::makeDir("asdf")}));
+
   OomdContext other;
   TestHelper::setCgroupData(
       other,
@@ -61,7 +64,6 @@ TEST_F(OomdContextTest, MoveConstructor) {
           .current_usage = 1, .memory_low = 2, .average_usage = 3});
 
   ctx = std::move(other);
-  F::materialize(F::makeDir(tempdir_, {F::makeDir("asdf")}));
 
   ASSERT_THAT(ctx.cgroups(), ElementsAre(path));
   auto moved_cgroup_ctx = ctx.addToCacheAndGet(path);

--- a/src/oomd/plugins/CorePluginsTest.cpp
+++ b/src/oomd/plugins/CorePluginsTest.cpp
@@ -3034,8 +3034,8 @@ class SenpaiTest : public CorePluginsTest {
       EXPECT_EQ(plugin_->run(ctx), Engine::PluginRet::CONTINUE);
       ctx.refresh();
     }
-    auto senpai_test_slice = Fs::DirFd::open(tempdir_ + "/senpai_test.slice");
-    EXPECT_TRUE(senpai_test_slice.isValid());
+    auto senpai_test_slice =
+        ASSERT_EXISTS(Fs::DirFd::open(tempdir_ + "/senpai_test.slice"));
     EXPECT_EQ(Fs::readMemhightmpAt(senpai_test_slice), limit);
   }
 
@@ -3045,8 +3045,8 @@ class SenpaiTest : public CorePluginsTest {
     const PluginConstructionContext compile_context(tempdir_);
     ASSERT_EQ(plugin_->init(std::move(args_), compile_context), 0);
 
-    auto senpai_test_slice = Fs::DirFd::open(tempdir_ + "/senpai_test.slice");
-    EXPECT_TRUE(senpai_test_slice.isValid());
+    auto senpai_test_slice =
+        ASSERT_EXISTS(Fs::DirFd::open(tempdir_ + "/senpai_test.slice"));
 
     OomdContext ctx;
     EXPECT_EQ(plugin_->run(ctx), Engine::PluginRet::CONTINUE);
@@ -3078,8 +3078,8 @@ TEST_F(SenpaiTest, FallbackMemHigh) {
   OomdContext ctx;
   EXPECT_EQ(plugin_->run(ctx), Engine::PluginRet::CONTINUE);
   // Same as memory.current
-  auto senpai_test_slice = Fs::DirFd::open(tempdir_ + "/senpai_test.slice");
-  EXPECT_TRUE(senpai_test_slice.isValid());
+  auto senpai_test_slice =
+      ASSERT_EXISTS(Fs::DirFd::open(tempdir_ + "/senpai_test.slice"));
   EXPECT_EQ(Fs::readMemhighAt(senpai_test_slice), 40960000);
 }
 
@@ -3092,8 +3092,8 @@ TEST_F(SenpaiTest, PreferMemHighTmp) {
   OomdContext ctx;
   EXPECT_EQ(plugin_->run(ctx), Engine::PluginRet::CONTINUE);
   // Same as memory.current
-  auto senpai_test_slice = Fs::DirFd::open(tempdir_ + "/senpai_test.slice");
-  EXPECT_TRUE(senpai_test_slice.isValid());
+  auto senpai_test_slice =
+      ASSERT_EXISTS(Fs::DirFd::open(tempdir_ + "/senpai_test.slice"));
   EXPECT_EQ(Fs::readMemhightmpAt(senpai_test_slice), 40960000);
   EXPECT_EQ(
       Fs::readMemhighAt(senpai_test_slice),

--- a/src/oomd/util/FsTest.cpp
+++ b/src/oomd/util/FsTest.cpp
@@ -23,6 +23,7 @@
 
 #include "oomd/fixtures/FsFixture.h"
 #include "oomd/util/Fs.h"
+#include "oomd/util/TestHelper.h"
 
 using namespace Oomd;
 using namespace testing;
@@ -142,32 +143,29 @@ TEST_F(FsTest, ReadFile) {
   EXPECT_EQ(lines[2], "");
   EXPECT_EQ(lines[3], "1");
 
-  auto dir = Fs::DirFd::open(fixture_.fsDataDir() + "/dir1");
-  ASSERT_TRUE(dir.isValid());
+  auto dir = ASSERT_EXISTS(Fs::DirFd::open(fixture_.fsDataDir() + "/dir1"));
   ASSERT_EQ(Fs::readFileByLine(Fs::Fd::openat(dir, "stuff")), lines);
 }
 
 TEST_F(FsTest, ReadFileBad) {
-  auto file = fixture_.fsDataDir() + "/ksldjfksdlfdsjf";
-  auto lines = Fs::readFileByLine(file);
-  ASSERT_EQ(lines.size(), 0);
+  auto path = fixture_.cgroupDataDir();
+  auto dir = ASSERT_EXISTS(Fs::DirFd::open(path));
+  EXPECT_EQ(Fs::readIsPopulatedAt(dir), true);
 
-  auto dir = Fs::DirFd::open(fixture_.fsDataDir());
-  ASSERT_TRUE(dir.isValid());
-  ASSERT_EQ(Fs::readFileByLine(Fs::Fd::openat(dir, "ksldjfksdlfdsjf")), lines);
+  auto path2 = fixture_.cgroupDataDir() + "/service3.service";
+  auto dir2 = ASSERT_EXISTS(Fs::DirFd::open(path2));
+  EXPECT_EQ(Fs::readIsPopulatedAt(dir2), false);
 }
 
 TEST_F(FsTest, GetPids) {
   auto path = fixture_.cgroupDataDir();
-  auto dir = Fs::DirFd::open(path);
-  EXPECT_TRUE(dir.isValid());
+  auto dir = ASSERT_EXISTS(Fs::DirFd::open(path));
   auto pids = Fs::getPidsAt(dir);
   EXPECT_EQ(pids.size(), 1);
   EXPECT_THAT(pids, Contains(123));
 
   auto path2 = path + "/service1.service";
-  auto dir2 = Fs::DirFd::open(path2);
-  EXPECT_TRUE(dir2.isValid());
+  auto dir2 = ASSERT_EXISTS(Fs::DirFd::open(path2));
   auto pids2 = Fs::getPidsAt(dir2);
   EXPECT_EQ(pids2.size(), 2);
   EXPECT_THAT(pids2, Contains(456));
@@ -175,77 +173,65 @@ TEST_F(FsTest, GetPids) {
 }
 
 TEST_F(FsTest, ReadIsPopulated) {
-  auto path = fixture_.cgroupDataDir();
-  auto dir = Fs::DirFd::open(path);
-  EXPECT_TRUE(dir.isValid());
-  EXPECT_EQ(Fs::readIsPopulatedAt(dir), true);
+  auto dir1 = ASSERT_EXISTS(Fs::DirFd::open(fixture_.cgroupDataDir()));
+  EXPECT_EQ(Fs::readIsPopulatedAt(dir1), true);
 
-  auto path2 = fixture_.cgroupDataDir() + "/service3.service";
-  auto dir2 = Fs::DirFd::open(path2);
-  EXPECT_TRUE(dir2.isValid());
+  auto dir2 = ASSERT_EXISTS(
+      Fs::DirFd::open(fixture_.cgroupDataDir() + "/service3.service"));
   EXPECT_EQ(Fs::readIsPopulatedAt(dir2), false);
 }
 
 TEST_F(FsTest, GetNrDying) {
   auto path = fixture_.cgroupDataDir();
-  auto dir = Fs::DirFd::open(path);
-  EXPECT_TRUE(dir.isValid());
+  auto dir = ASSERT_EXISTS(Fs::DirFd::open(path));
   EXPECT_EQ(Fs::getNrDyingDescendantsAt(dir), 27);
 }
 
 TEST_F(FsTest, ReadMemoryCurrent) {
   auto path = fixture_.cgroupDataDir();
-  auto dir = Fs::DirFd::open(path);
-  EXPECT_TRUE(dir.isValid());
+  auto dir = ASSERT_EXISTS(Fs::DirFd::open(path));
   EXPECT_EQ(Fs::readMemcurrentAt(dir), 987654321);
 }
 
 TEST_F(FsTest, ReadMemoryLow) {
   auto path = fixture_.cgroupDataDir();
-  auto dir = Fs::DirFd::open(path);
-  EXPECT_TRUE(dir.isValid());
+  auto dir = ASSERT_EXISTS(Fs::DirFd::open(path));
   EXPECT_EQ(Fs::readMemlowAt(dir), 333333);
 }
 
 TEST_F(FsTest, ReadMemoryMin) {
   auto path = fixture_.cgroupDataDir();
-  auto dir = Fs::DirFd::open(path);
-  EXPECT_TRUE(dir.isValid());
+  auto dir = ASSERT_EXISTS(Fs::DirFd::open(path));
   EXPECT_EQ(Fs::readMemminAt(dir), 666);
 }
 
 TEST_F(FsTest, ReadMemoryHigh) {
   auto path = fixture_.cgroupDataDir();
-  auto dir = Fs::DirFd::open(path);
-  EXPECT_TRUE(dir.isValid());
+  auto dir = ASSERT_EXISTS(Fs::DirFd::open(path));
   EXPECT_EQ(Fs::readMemhighAt(dir), 1000);
 }
 
 TEST_F(FsTest, ReadMemoryMax) {
   auto path = fixture_.cgroupDataDir();
-  auto dir = Fs::DirFd::open(path);
-  EXPECT_TRUE(dir.isValid());
+  auto dir = ASSERT_EXISTS(Fs::DirFd::open(path));
   EXPECT_EQ(Fs::readMemmaxAt(dir), 654);
 }
 
 TEST_F(FsTest, ReadMemoryHighTmp) {
   auto path = fixture_.cgroupDataDir();
-  auto dir = Fs::DirFd::open(path);
-  EXPECT_TRUE(dir.isValid());
+  auto dir = ASSERT_EXISTS(Fs::DirFd::open(path));
   EXPECT_EQ(Fs::readMemhightmpAt(dir), 2000);
 }
 
 TEST_F(FsTest, ReadSwapCurrent) {
   auto path = fixture_.cgroupDataDir();
-  auto dir = Fs::DirFd::open(path);
-  EXPECT_TRUE(dir.isValid());
+  auto dir = ASSERT_EXISTS(Fs::DirFd::open(path));
   EXPECT_EQ(Fs::readSwapCurrentAt(dir), 321321);
 }
 
 TEST_F(FsTest, ReadControllers) {
   auto path = fixture_.cgroupDataDir();
-  auto dir = Fs::DirFd::open(path);
-  EXPECT_TRUE(dir.isValid());
+  auto dir = ASSERT_EXISTS(Fs::DirFd::open(path));
   auto controllers = Fs::readControllersAt(dir);
 
   ASSERT_EQ(controllers.size(), 4);
@@ -259,8 +245,7 @@ TEST_F(FsTest, ReadControllers) {
 TEST_F(FsTest, ReadMemoryPressure) {
   // v4.16+ upstream format
   auto path = fixture_.cgroupDataDir();
-  auto dir = Fs::DirFd::open(path);
-  EXPECT_TRUE(dir.isValid());
+  auto dir = ASSERT_EXISTS(Fs::DirFd::open(path));
   auto pressure = Fs::readMempressureAt(dir);
 
   EXPECT_FLOAT_EQ(pressure.sec_10, 4.44);
@@ -269,8 +254,7 @@ TEST_F(FsTest, ReadMemoryPressure) {
 
   // old experimental format
   auto path2 = path + "/service2.service";
-  auto dir2 = Fs::DirFd::open(path2);
-  EXPECT_TRUE(dir2.isValid());
+  auto dir2 = ASSERT_EXISTS(Fs::DirFd::open(path2));
   auto pressure2 = Fs::readMempressureAt(dir2);
 
   EXPECT_FLOAT_EQ(pressure2.sec_10, 4.44);
@@ -279,8 +263,7 @@ TEST_F(FsTest, ReadMemoryPressure) {
 
   // old experimental format w/ debug info on
   auto path3 = path + "/service3.service";
-  auto dir3 = Fs::DirFd::open(path3);
-  EXPECT_TRUE(dir3.isValid());
+  auto dir3 = ASSERT_EXISTS(Fs::DirFd::open(path3));
   auto pressure3 = Fs::readMempressureAt(dir3);
 
   EXPECT_FLOAT_EQ(pressure3.sec_10, 4.44);
@@ -291,8 +274,7 @@ TEST_F(FsTest, ReadMemoryPressure) {
 TEST_F(FsTest, ReadMemoryPressureSome) {
   // v4.16+ upstream format
   auto path = fixture_.cgroupDataDir();
-  auto dir = Fs::DirFd::open(path);
-  EXPECT_TRUE(dir.isValid());
+  auto dir = ASSERT_EXISTS(Fs::DirFd::open(path));
   auto pressure = Fs::readMempressureAt(dir, Fs::PressureType::SOME);
 
   EXPECT_FLOAT_EQ(pressure.sec_10, 1.11);
@@ -301,8 +283,7 @@ TEST_F(FsTest, ReadMemoryPressureSome) {
 
   // old experimental format
   auto path2 = path + "/service2.service";
-  auto dir2 = Fs::DirFd::open(path2);
-  EXPECT_TRUE(dir2.isValid());
+  auto dir2 = ASSERT_EXISTS(Fs::DirFd::open(path2));
   auto pressure2 = Fs::readMempressureAt(dir2, Fs::PressureType::SOME);
 
   EXPECT_FLOAT_EQ(pressure2.sec_10, 1.11);
@@ -337,8 +318,7 @@ TEST_F(FsTest, GetMeminfo) {
 
 TEST_F(FsTest, GetMemstat) {
   auto path = fixture_.cgroupDataDir();
-  auto dir = Fs::DirFd::open(path);
-  EXPECT_TRUE(dir.isValid());
+  auto dir = ASSERT_EXISTS(Fs::DirFd::open(path));
   auto meminfo = Fs::getMemstatAt(dir);
 
   EXPECT_EQ(meminfo.size(), 29);
@@ -352,8 +332,7 @@ TEST_F(FsTest, GetMemstat) {
 
 TEST_F(FsTest, ReadIoPressure) {
   auto path = fixture_.cgroupDataDir();
-  auto dir = Fs::DirFd::open(path);
-  EXPECT_TRUE(dir.isValid());
+  auto dir = ASSERT_EXISTS(Fs::DirFd::open(path));
   auto pressure = Fs::readIopressureAt(dir);
 
   EXPECT_FLOAT_EQ(pressure.sec_10, 4.45);
@@ -363,8 +342,7 @@ TEST_F(FsTest, ReadIoPressure) {
 
 TEST_F(FsTest, ReadIoPressureSome) {
   auto path = fixture_.cgroupDataDir();
-  auto dir = Fs::DirFd::open(path);
-  EXPECT_TRUE(dir.isValid());
+  auto dir = ASSERT_EXISTS(Fs::DirFd::open(path));
   auto pressure = Fs::readIopressureAt(dir, Fs::PressureType::SOME);
 
   EXPECT_FLOAT_EQ(pressure.sec_10, 1.12);
@@ -374,13 +352,11 @@ TEST_F(FsTest, ReadIoPressureSome) {
 
 TEST_F(FsTest, ReadMemoryOomGroup) {
   auto path1 = fixture_.cgroupDataDir() + "/slice1.slice";
-  auto dir1 = Fs::DirFd::open(path1);
-  EXPECT_TRUE(dir1.isValid());
+  auto dir1 = ASSERT_EXISTS(Fs::DirFd::open(path1));
   EXPECT_EQ(Fs::readMemoryOomGroupAt(dir1), true);
 
   auto path2 = fixture_.cgroupDataDir() + "/slice1.slice/service1.service";
-  auto dir2 = Fs::DirFd::open(path2);
-  EXPECT_TRUE(dir2.isValid());
+  auto dir2 = ASSERT_EXISTS(Fs::DirFd::open(path2));
   EXPECT_EQ(Fs::readMemoryOomGroupAt(dir2), false);
 }
 
@@ -429,9 +405,7 @@ TEST_F(FsTest, GetDeviceType) {
 TEST_F(FsTest, ReadIostat) {
   auto path = fixture_.cgroupDataDir();
 
-  auto dir = Fs::DirFd::open(path);
-  EXPECT_TRUE(dir.isValid());
-
+  auto dir = ASSERT_EXISTS(Fs::DirFd::open(path));
   auto io_stat = Fs::readIostatAt(dir);
   EXPECT_EQ(io_stat.size(), 2);
 
@@ -459,8 +433,7 @@ TEST_F(FsTest, WriteMemoryHigh) {
   auto path = fixture_.cgroupDataDir() + "/write_test";
   F::materialize(F::makeDir(path, {F::makeFile("memory.high")}));
 
-  auto dir = Fs::DirFd::open(path);
-  EXPECT_TRUE(dir.isValid());
+  auto dir = ASSERT_EXISTS(Fs::DirFd::open(path));
   Fs::writeMemhighAt(dir, 54321);
   EXPECT_EQ(Fs::readMemhighAt(dir), 54321);
 }
@@ -470,8 +443,7 @@ TEST_F(FsTest, WriteMemoryHighTmp) {
   auto path = fixture_.cgroupDataDir() + "/write_test";
   F::materialize(F::makeDir(path, {F::makeFile("memory.high.tmp")}));
 
-  auto dir = Fs::DirFd::open(path);
-  EXPECT_TRUE(dir.isValid());
+  auto dir = ASSERT_EXISTS(Fs::DirFd::open(path));
   Fs::writeMemhightmpAt(dir, 54321, std::chrono::microseconds{400000});
   EXPECT_EQ(Fs::readMemhightmpAt(dir), 54321);
 }

--- a/src/oomd/util/TestHelper.h
+++ b/src/oomd/util/TestHelper.h
@@ -20,6 +20,13 @@
 #include "oomd/CgroupContext.h"
 #include "oomd/OomdContext.h"
 
+#define ASSERT_EXISTS(opt_expr) \
+  ({                            \
+    auto x = (opt_expr);        \
+    ASSERT_TRUE(x.has_value()); \
+    std::move(*x);              \
+  })
+
 namespace Oomd {
 
 /*
@@ -50,7 +57,11 @@ class TestHelper {
       OomdContext& ctx,
       const CgroupPath& cgroup,
       const CgroupData& data) {
-    *ctx.cgroups_.try_emplace(cgroup, ctx, cgroup).first->second.data_ = data;
+    auto cgroup_ctx = CgroupContext::make(ctx, cgroup);
+    if (cgroup_ctx.has_value()) {
+      *ctx.cgroups_.emplace(cgroup, std::move(*cgroup_ctx))
+           .first->second.data_ = data;
+    }
   }
 };
 


### PR DESCRIPTION
Summary: [refactor] use the type system to ensure we never have invalid Fds that we forget to check.

Reviewed By: dschatzberg

Differential Revision: D22218052

