### PR TITLE
Fix open source build

### DIFF
--- a/src/oomd/Oomd.cpp
+++ b/src/oomd/Oomd.cpp
@@ -79,8 +79,6 @@ void Oomd::updateContext() {
 }
 
 int Oomd::run() {
-  int ret;
-
   if (!engine_) {
     OLOG << "Could not run engine. Your config file is probably invalid\n";
     return EXIT_CANT_RECOVER;

--- a/src/oomd/util/Fs.cpp
+++ b/src/oomd/util/Fs.cpp
@@ -343,6 +343,7 @@ std::string Fs::pressureTypeToString(PressureType type) {
     case PressureType::FULL:
       return "full";
   }
+  __builtin_unreachable();
 }
 
 SystemMaybe<ResourcePressure> Fs::readRespressureFromLines(
@@ -419,6 +420,7 @@ SystemMaybe<ResourcePressure> Fs::readRespressureFromLines(
     case PsiFormat::INVALID:
       return SYSTEM_ERROR(EINVAL);
   }
+  __builtin_unreachable();
 }
 
 SystemMaybe<int64_t> Fs::readRootMemcurrent() {
@@ -688,8 +690,6 @@ SystemMaybe<IOStat> Fs::readIostatAt(const DirFd& dirfd) {
 SystemMaybe<Unit> Fs::writeControlFileAt(
     SystemMaybe<Fd>&& fd,
     const std::string& content) {
-  char buf[1024];
-  buf[0] = '\0';
   if (!fd) {
     return SYSTEM_ERROR(fd.error());
   }

--- a/src/oomd/util/FsTest.cpp
+++ b/src/oomd/util/FsTest.cpp
@@ -145,9 +145,10 @@ TEST_F(FsTest, ReadFile) {
   EXPECT_EQ(lines[3], "1");
 
   auto dir = ASSERT_SYS_OK(Fs::DirFd::open(fixture_.fsDataDir() + "/dir1"));
+  auto openat_lines =
+      ASSERT_SYS_OK(Fs::readFileByLine(Fs::Fd::openat(dir, "stuff")));
 
-  ASSERT_EQ(
-      ASSERT_SYS_OK(Fs::readFileByLine(Fs::Fd::openat(dir, "stuff"))), lines);
+  ASSERT_EQ(openat_lines, lines);
 }
 
 TEST_F(FsTest, ReadFileBad) {
@@ -175,11 +176,13 @@ TEST_F(FsTest, GetPids) {
 
 TEST_F(FsTest, ReadIsPopulated) {
   auto dir1 = ASSERT_SYS_OK(Fs::DirFd::open(fixture_.cgroupDataDir()));
-  EXPECT_EQ(ASSERT_SYS_OK(Fs::readIsPopulatedAt(dir1)), true);
+  auto isPopulated1 = ASSERT_SYS_OK(Fs::readIsPopulatedAt(dir1));
+  EXPECT_TRUE(isPopulated1);
 
   auto dir2 = ASSERT_SYS_OK(
       Fs::DirFd::open(fixture_.cgroupDataDir() + "/service3.service"));
-  EXPECT_EQ(ASSERT_SYS_OK(Fs::readIsPopulatedAt(dir2)), false);
+  auto isPopulated2 = ASSERT_SYS_OK(Fs::readIsPopulatedAt(dir2));
+  EXPECT_FALSE(isPopulated2);
 }
 
 TEST_F(FsTest, GetNrDying) {
@@ -436,7 +439,8 @@ TEST_F(FsTest, WriteMemoryHigh) {
 
   auto dir = ASSERT_SYS_OK(Fs::DirFd::open(path));
   ASSERT_SYS_OK(Fs::writeMemhighAt(dir, 54321));
-  EXPECT_EQ(ASSERT_SYS_OK(Fs::readMemhighAt(dir)), 54321);
+  auto memhigh = ASSERT_SYS_OK(Fs::readMemhighAt(dir));
+  EXPECT_EQ(memhigh, 54321);
 }
 
 TEST_F(FsTest, WriteMemoryHighTmp) {
@@ -447,5 +451,6 @@ TEST_F(FsTest, WriteMemoryHighTmp) {
   auto dir = ASSERT_SYS_OK(Fs::DirFd::open(path));
   ASSERT_SYS_OK(
       Fs::writeMemhightmpAt(dir, 54321, std::chrono::microseconds{400000}));
-  EXPECT_EQ(ASSERT_SYS_OK(Fs::readMemhightmpAt(dir)), 54321);
+  auto memhightmp = ASSERT_SYS_OK(Fs::readMemhightmpAt(dir));
+  EXPECT_EQ(memhightmp, 54321);
 }

--- a/src/oomd/util/SystemMaybe.h
+++ b/src/oomd/util/SystemMaybe.h
@@ -196,16 +196,16 @@ auto systemError(std::system_error err, Msg&&... msg) {
   ::Oomd::systemError(c, "[", __FILE__, ":", __LINE__, "] ", ##__VA_ARGS__)
 
 namespace {
-auto noSystemError() {
+[[maybe_unused]] auto noSystemError() {
   return SystemMaybe<Unit>();
 }
 } // namespace
 
-#define ASSERT_SYS_OK(maybe)                    \
-  ({                                            \
-    auto x = (maybe);                           \
-    ASSERT_TRUE(maybe) << maybe.error().what(); \
-    std::move(*x);                              \
+#define ASSERT_SYS_OK(maybe)            \
+  ({                                    \
+    auto x = (maybe);                   \
+    ASSERT_TRUE(x) << x.error().what(); \
+    std::move(*x);                      \
   })
 
 } // namespace Oomd


### PR DESCRIPTION
Summary: Fix compiler errors and warnings in open source build (gcc8 and g++8).

Differential Revision: D24163155

