### PR TITLE
remove workflow to check format

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,15 +9,6 @@ on:
     - master
 
 jobs:
-  check-format:
-    name: Check clang format
-    runs-on: ubuntu-latest
-    steps:
-      - run: sudo apt-get install clang-format
-      - name: Checkout code
-        uses: actions/checkout@v2
-      - run: ./clang-format.sh
-      - run: git diff --exit-code
   build:
     name: Build and test repo
     runs-on: ubuntu-latest

--- a/src/oomd/plugins/SenpaiHold.h
+++ b/src/oomd/plugins/SenpaiHold.h
@@ -108,10 +108,6 @@ class SenpaiHold : public SenpaiCommon<SenpaiHold> {
   SystemMaybe<Unit> resetLimit(
       const CgroupContext& cgroup_ctx,
       CgroupState& state);
-  SystemMaybe<bool> validatePressure(const CgroupContext& cgroup_ctx) const;
-  SystemMaybe<bool> validateSwap(const CgroupContext& cgroup_ctx) const;
-  SystemMaybe<double> calculateSwappinessFactor(
-      const CgroupContext& cgroup_ctx) const;
 
   std::shared_ptr<EpollThreadState> epoll_thread_state_;
   std::thread epoll_thread_;

--- a/src/oomd/plugins/SenpaiHold.h
+++ b/src/oomd/plugins/SenpaiHold.h
@@ -95,7 +95,7 @@ class SenpaiHold : public SenpaiCommon<SenpaiHold> {
     return new SenpaiHold();
   }
 
-  using CgroupState = CgroupState<SenpaiHold>;
+  using CgroupState = Oomd::CgroupState<SenpaiHold>;
 
   SystemMaybe<Unit> initializeCgroup(
       const CgroupContext& cgroup_ctx,

--- a/src/oomd/plugins/SenpaiPoking.h
+++ b/src/oomd/plugins/SenpaiPoking.h
@@ -42,7 +42,7 @@ class SenpaiPoking : public SenpaiCommon<SenpaiPoking> {
     return new SenpaiPoking();
   }
 
-  using CgroupState = CgroupState<SenpaiPoking>;
+  using CgroupState = Oomd::CgroupState<SenpaiPoking>;
 
   SystemMaybe<Unit> initializeCgroup(
       const CgroupContext& cgroup_ctx,


### PR DESCRIPTION
Summary: We have an internal auto formatter that may disagree with the available clang-format version. Let's don't make bad format a CI error.

Differential Revision: D26394807

