### PR TITLE
add plugin arg parser util

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -42,8 +42,6 @@ srcs = files('''
     src/oomd/plugins/StopPlugin.cpp
     src/oomd/plugins/DumpCgroupOverview.cpp
     src/oomd/plugins/DumpKillInfoNoOp.cpp
-    src/oomd/util/Fs.cpp
-    src/oomd/util/Util.cpp
     src/oomd/plugins/MemoryAbove.cpp
     src/oomd/plugins/MemoryReclaim.cpp
     src/oomd/plugins/NrDyingDescendants.cpp
@@ -56,6 +54,9 @@ srcs = files('''
     src/oomd/plugins/KillSwapUsage.cpp
     src/oomd/plugins/KillPgScan.cpp
     src/oomd/plugins/KillPressure.cpp
+    src/oomd/util/Fs.cpp
+    src/oomd/util/Util.cpp
+    src/oomd/util/PluginArgParser.cpp
 '''.split())
 
 fixture_srcs = files('''
@@ -134,7 +135,8 @@ core_tests = [
                      'src/oomd/util/FsTest.cpp',
                      'src/oomd/util/ScopeGuardTest.cpp',
                      'src/oomd/util/SystemMaybeTest.cpp',
-                     'src/oomd/util/UtilTest.cpp')],
+                     'src/oomd/util/UtilTest.cpp',
+                     'src/oomd/util/PluginArgParserTest.cpp')],
   ['cgctx',    files('src/oomd/CgroupContextTest.cpp')],
   ['context',  files('src/oomd/OomdContextTest.cpp')],
   ['log',      files('src/oomd/LogTest.cpp')],

--- a/src/oomd/PluginConstructionContext.h
+++ b/src/oomd/PluginConstructionContext.h
@@ -22,10 +22,6 @@
 
 namespace Oomd {
 
-namespace Engine {
-using PluginArgs = std::unordered_map<std::string, std::string>;
-}
-
 class PluginConstructionContext {
  public:
   PluginConstructionContext(const std::string& cgroup_fs);

--- a/src/oomd/config/ConfigCompilerTest.cpp
+++ b/src/oomd/config/ConfigCompilerTest.cpp
@@ -361,7 +361,6 @@ TEST_F(CompilerTest, AsyncAction) {
   root.rulesets = {
       IR::Ruleset{
           .name = "async_pausing",
-          .post_action_delay = "0",
           .dgs = {dg},
           .acts =
               {inc,
@@ -372,12 +371,13 @@ TEST_F(CompilerTest, AsyncAction) {
                inc,
                pause, // (2)
                inc,
-               stop}}, // (3)
+               stop},
+          .post_action_delay = "0"}, // (3)
       IR::Ruleset{
           .name = "concurrently_always_running",
-          .post_action_delay = "0",
           .dgs = {dg},
-          .acts = {inc}},
+          .acts = {inc},
+          .post_action_delay = "0"},
   };
 
   auto engine = compile();
@@ -423,7 +423,6 @@ TEST_F(CompilerTest, TwoChainsIndependentlyPaused) {
   root.rulesets = {
       IR::Ruleset{
           .name = "A",
-          .post_action_delay = "0",
           .dgs = {always_yes},
           .acts =
               {inc,
@@ -434,21 +433,22 @@ TEST_F(CompilerTest, TwoChainsIndependentlyPaused) {
                inc,
                pause, // (2)
                inc,
-               stop}}, // (3)
+               stop},
+          .post_action_delay = "0"}, // (3)
       IR::Ruleset{
           .name = "B",
-          .post_action_delay = "0",
           .dgs = {IR::DetectorGroup{
               .name = "ctld",
               .detectors = {IR::Detector{
                   IR::Plugin{.name = "ControlledDetector"}}}}},
-          .acts = {
-              inc,
-              inc,
-              inc,
-              pause, // (4)
-              inc,
-              inc}}}; // (5)
+          .acts =
+              {inc,
+               inc,
+               inc,
+               pause, // (4)
+               inc,
+               inc},
+          .post_action_delay = "0"}}; // (5)
 
   auto engine = compile();
   ASSERT_TRUE(engine);
@@ -515,49 +515,49 @@ TEST_F(DropInCompilerTest, PrerunCount) {
       // 2 / 0 plugins with/without dropin
       IR::Ruleset{
           .name = "disabled_dropin_target",
-          .post_action_delay = "0",
           .dgs = {IR::DetectorGroup{
               .name = "group1", .detectors = {IR::Detector{cont}}}},
           .acts = {IR::Action{cont}},
           .dropin =
               IR::DropIn{
-                  .disable_on_drop_in = true, .actiongroup_enabled = true}},
+                  .disable_on_drop_in = true, .actiongroup_enabled = true},
+          .post_action_delay = "0"},
       // 3 plugins (action won't be taken as we stop early)
       IR::Ruleset{
           .name = "enabled_dropin_target",
-          .post_action_delay = "0",
           .dgs = {IR::DetectorGroup{
               .name = "group1",
               .detectors = {IR::Detector{stop}, IR::Detector{cont}}}},
           .acts = {IR::Action{cont}},
           .dropin =
               IR::DropIn{
-                  .disable_on_drop_in = false, .actiongroup_enabled = true}},
+                  .disable_on_drop_in = false, .actiongroup_enabled = true},
+          .post_action_delay = "0"},
       // 2 plugins (StoreCount stores prerun_count)
       IR::Ruleset{
           .name = "rs",
-          .post_action_delay = "0",
           .dgs = {IR::DetectorGroup{
               .name = "group1", .detectors = {IR::Detector{cont}}}},
-          .acts = {IR::Action{IR::Plugin{.name = "StoreCount"}}}},
+          .acts = {IR::Action{IR::Plugin{.name = "StoreCount"}}},
+          .post_action_delay = "0"},
   };
   // Plugins from dropin should also be prerun()
   dropin_ir.rulesets = {
       // 1 + 2 = 3 plugins
       IR::Ruleset{
           .name = "disabled_dropin_target",
-          .post_action_delay = "0",
           .acts =
               {IR::Action{IR::Plugin{.name = "IncrementCount"}},
-               IR::Action{IR::Plugin{.name = "IncrementCount"}}}},
+               IR::Action{IR::Plugin{.name = "IncrementCount"}}},
+          .post_action_delay = "0"},
       // 2 + 3 = 5 plugins
       IR::Ruleset{
           .name = "enabled_dropin_target",
-          .post_action_delay = "0",
           .acts =
               {IR::Action{IR::Plugin{.name = "IncrementCount"}},
                IR::Action{IR::Plugin{.name = "IncrementCount"}},
-               IR::Action{IR::Plugin{.name = "IncrementCount"}}}},
+               IR::Action{IR::Plugin{.name = "IncrementCount"}}},
+          .post_action_delay = "0"},
   };
 
   auto engine = compileBase();
@@ -599,10 +599,10 @@ TEST_F(CompilerTest, SilenceLogsParse) {
   IR::DetectorGroup dgroup{.name = "group1", .detectors = {cont}};
   IR::Ruleset ruleset{
       .name = "ruleset1",
-      .post_action_delay = "0",
       .dgs = {std::move(dgroup)},
       .acts = {cont_act},
       .silence_logs = "engine,plugins",
+      .post_action_delay = "0",
   };
   root.rulesets.emplace_back(std::move(ruleset));
 

--- a/src/oomd/engine/BasePlugin.h
+++ b/src/oomd/engine/BasePlugin.h
@@ -25,6 +25,7 @@
 #include "oomd/PluginConstructionContext.h"
 #include "oomd/include/CgroupPath.h"
 #include "oomd/include/Types.h"
+#include "oomd/util/PluginArgParser.h"
 
 namespace Oomd {
 namespace Engine {
@@ -77,12 +78,16 @@ class BasePlugin {
 
   virtual void setName(const std::string& name) {
     name_ = name;
+    argParser_.setName(name_);
   }
   virtual const std::string& getName() const {
     return name_;
   }
 
   virtual ~BasePlugin() = default;
+
+ protected:
+  PluginArgParser argParser_;
 
  private:
   std::string name_;

--- a/src/oomd/include/Types.h
+++ b/src/oomd/include/Types.h
@@ -20,9 +20,14 @@
 #include <chrono>
 #include <cstdint>
 #include <iostream>
+#include <unordered_map>
 #include <vector>
 
 namespace Oomd {
+
+namespace Engine {
+using PluginArgs = std::unordered_map<std::string, std::string>;
+}
 
 enum struct ResourceType {
   MEMORY,

--- a/src/oomd/plugins/BaseKillPlugin.cpp
+++ b/src/oomd/plugins/BaseKillPlugin.cpp
@@ -53,59 +53,25 @@ namespace Oomd {
 int BaseKillPlugin::init(
     const Engine::PluginArgs& args,
     const PluginConstructionContext& context) {
-  if (args.find("cgroup") != args.end()) {
-    const auto& cgroup_fs = context.cgroupFs();
+  argParser_.addArgumentCustom(
+      "cgroup",
+      cgroups_,
+      [context](const std::string& cgroupStr) {
+        return PluginArgParser::parseCgroup(context, cgroupStr);
+      },
+      true);
 
-    auto cgroups = Util::split(args.at("cgroup"), ',');
-    for (const auto& c : cgroups) {
-      cgroups_.emplace(cgroup_fs, c);
-    }
-  } else {
-    OLOG << "Argument=cgroup not present";
+  argParser_.addArgument("recursive", recursive_);
+  argParser_.addArgumentCustom(
+      "post_action_delay",
+      post_action_delay_,
+      PluginArgParser::parseUnsignedInt);
+  argParser_.addArgument("dry", dry_);
+  argParser_.addArgument("always_continue", always_continue_);
+  argParser_.addArgument("debug", debug_);
+
+  if (!argParser_.parse(args)) {
     return 1;
-  }
-
-  if (args.find("recursive") != args.end()) {
-    const std::string& val = args.at("recursive");
-
-    if (val == "true" || val == "True" || val == "1") {
-      recursive_ = true;
-    }
-  }
-
-  if (args.find("post_action_delay") != args.end()) {
-    int val = std::stoi(args.at("post_action_delay"));
-
-    if (val < 0) {
-      OLOG << "Argument=post_action_delay must be non-negative";
-      return 1;
-    }
-
-    post_action_delay_ = val;
-  }
-
-  if (args.find("dry") != args.end()) {
-    const std::string& val = args.at("dry");
-
-    if (val == "true" || val == "True" || val == "1") {
-      dry_ = true;
-    }
-  }
-
-  if (args.find("always_continue") != args.end()) {
-    const std::string& val = args.at("always_continue");
-
-    if (val == "true" || val == "True" || val == "1") {
-      always_continue_ = true;
-    }
-  }
-
-  if (args.find("debug") != args.end()) {
-    const std::string& val = args.at("debug");
-
-    if (val == "true" || val == "True" || val == "1") {
-      debug_ = true;
-    }
   }
 
   // Success

--- a/src/oomd/plugins/CorePluginsTest.cpp
+++ b/src/oomd/plugins/CorePluginsTest.cpp
@@ -1264,7 +1264,6 @@ TEST_F(SwapFreeTest, LowSwap) {
 
   Engine::PluginArgs args;
   args["threshold_pct"] = "20";
-  args["duration"] = "0";
   const PluginConstructionContext compile_context("/sys/fs/cgroup");
 
   ASSERT_EQ(plugin->init(std::move(args), compile_context), 0);
@@ -1282,7 +1281,6 @@ TEST_F(SwapFreeTest, EnoughSwap) {
 
   Engine::PluginArgs args;
   args["threshold_pct"] = "20";
-  args["duration"] = "0";
   const PluginConstructionContext compile_context("/sys/fs/cgroup");
 
   ASSERT_EQ(plugin->init(std::move(args), compile_context), 0);
@@ -1300,7 +1298,6 @@ TEST_F(SwapFreeTest, SwapOff) {
 
   Engine::PluginArgs args;
   args["threshold_pct"] = "20";
-  args["duration"] = "0";
   const PluginConstructionContext compile_context("/sys/fs/cgroup");
 
   ASSERT_EQ(plugin->init(std::move(args), compile_context), 0);
@@ -1410,7 +1407,6 @@ TEST_F(KillIOCostTest, KillsHighestIOCostMultiCgroup) {
   const PluginConstructionContext compile_context(
       "oomd/fixtures/plugins/kill_by_io_cost");
   args["cgroup"] = "one_high/*,sibling/*";
-  args["resource"] = "io";
   args["post_action_delay"] = "0";
 
   ASSERT_EQ(plugin->init(std::move(args), compile_context), 0);
@@ -1447,7 +1443,6 @@ TEST_F(KillIOCostTest, DoesntKillsHighestIOCostDry) {
   const PluginConstructionContext compile_context(
       "oomd/fixtures/plugins/kill_by_pressure");
   args["cgroup"] = "one_high/*";
-  args["resource"] = "io";
   args["post_action_delay"] = "0";
   args["dry"] = "true";
 
@@ -1548,7 +1543,6 @@ TEST_F(KillPgScanTest, KillsHighestPgScanMultiCgroup) {
   const PluginConstructionContext compile_context(
       "oomd/fixtures/plugins/kill_by_pg_scan");
   args["cgroup"] = "one_high/*,sibling/*";
-  args["resource"] = "io";
   args["post_action_delay"] = "0";
 
   ASSERT_EQ(plugin->init(std::move(args), compile_context), 0);
@@ -1585,7 +1579,6 @@ TEST_F(KillPgScanTest, DoesntKillsHighestPgScanDry) {
   const PluginConstructionContext compile_context(
       "oomd/fixtures/plugins/kill_by_pg_scan");
   args["cgroup"] = "one_high/*";
-  args["resource"] = "io";
   args["post_action_delay"] = "0";
   args["dry"] = "true";
 

--- a/src/oomd/plugins/DumpCgroupOverview.cpp
+++ b/src/oomd/plugins/DumpCgroupOverview.cpp
@@ -73,22 +73,18 @@ REGISTER_PLUGIN(dump_cgroup_overview, DumpCgroupOverview::create);
 int DumpCgroupOverview::init(
     const Engine::PluginArgs& args,
     const PluginConstructionContext& context) {
-  if (args.find("cgroup") != args.end()) {
-    const auto& cgroup_fs = context.cgroupFs();
-    auto cgroups = Util::split(args.at("cgroup"), ',');
-    for (const auto& c : cgroups) {
-      cgroups_.emplace(cgroup_fs, c);
-    }
-  } else {
-    OLOG << "Argument=cgroup not present";
-    return 1;
-  }
+  argParser_.addArgumentCustom(
+      "cgroup",
+      cgroups_,
+      [context](const std::string& cgroupStr) {
+        return PluginArgParser::parseCgroup(context, cgroupStr);
+      },
+      true);
 
-  if (args.find("always") != args.end()) {
-    const auto& var = args.at("always");
-    if (var == "true" || var == "True" || var == "1") {
-      always_ = true;
-    }
+  argParser_.addArgument("always", always_);
+
+  if (!argParser_.parse(args)) {
+    return 1;
   }
 
   return 0;

--- a/src/oomd/plugins/Exists.cpp
+++ b/src/oomd/plugins/Exists.cpp
@@ -32,32 +32,19 @@ REGISTER_PLUGIN(exists, Exists::create);
 int Exists::init(
     const Engine::PluginArgs& args,
     const PluginConstructionContext& context) {
-  if (args.find("cgroup") != args.end()) {
-    const auto& cgroup_fs = context.cgroupFs();
+  argParser_.addArgumentCustom(
+      "cgroup",
+      cgroups_,
+      [context](const std::string& cgroupStr) {
+        return PluginArgParser::parseCgroup(context, cgroupStr);
+      },
+      true);
 
-    auto cgroups = Util::split(args.at("cgroup"), ',');
-    for (const auto& c : cgroups) {
-      cgroups_.emplace(cgroup_fs, c);
-    }
-  } else {
-    OLOG << "Argument=cgroup not present";
+  argParser_.addArgument("negate", negate_);
+  argParser_.addArgument("debug", debug_);
+
+  if (!argParser_.parse(args)) {
     return 1;
-  }
-
-  if (args.find("negate") != args.end()) {
-    const std::string& val = args.at("negate");
-
-    if (val == "true" || val == "True" || val == "1") {
-      negate_ = true;
-    }
-  }
-
-  if (args.find("debug") != args.end()) {
-    const std::string& val = args.at("debug");
-
-    if (val == "true" || val == "True" || val == "1") {
-      debug_ = true;
-    }
   }
 
   // Success

--- a/src/oomd/plugins/KillMemoryGrowth-inl.h
+++ b/src/oomd/plugins/KillMemoryGrowth-inl.h
@@ -32,38 +32,16 @@ template <typename Base>
 int KillMemoryGrowth<Base>::init(
     const Engine::PluginArgs& args,
     const PluginConstructionContext& context) {
-  if (args.find("size_threshold") != args.end()) {
-    int val = std::stoi(args.at("size_threshold"));
+  this->argParser_.addArgumentCustom(
+      "size_threshold", size_threshold_, PluginArgParser::parseUnsignedInt);
 
-    if (val < 0) {
-      OLOG << "Argument=size_threshold must be non-negative";
-      return 1;
-    }
+  this->argParser_.addArgumentCustom(
+      "growing_size_percentile",
+      growing_size_percentile_,
+      PluginArgParser::parseUnsignedInt);
 
-    size_threshold_ = val;
-  }
-
-  if (args.find("growing_size_percentile") != args.end()) {
-    int val = std::stoi(args.at("growing_size_percentile"));
-
-    if (val < 0) {
-      OLOG << "Argument=growing_size_percentile must be non-negative";
-      return 1;
-    }
-
-    growing_size_percentile_ = val;
-  }
-
-  if (args.find("min_growth_ratio") != args.end()) {
-    float val = std::stof(args.at("min_growth_ratio"));
-
-    if (val < 0) {
-      OLOG << "Argument=min_growth_ratio must be non-negative";
-      return 1;
-    }
-
-    min_growth_ratio_ = val;
-  }
+  this->argParser_.addArgumentCustom(
+      "min_growth_ratio", min_growth_ratio_, PluginArgParser::parseUnsignedInt);
 
   return Base::init(args, context);
 }

--- a/src/oomd/plugins/KillPressure-inl.h
+++ b/src/oomd/plugins/KillPressure-inl.h
@@ -32,18 +32,7 @@ template <typename Base>
 int KillPressure<Base>::init(
     const Engine::PluginArgs& args,
     const PluginConstructionContext& context) {
-  if (args.find("resource") != args.end() &&
-      (args.at("resource") == "io" || args.at("resource") == "memory")) {
-    const auto& res = args.at("resource");
-    if (res == "io") {
-      resource_ = ResourceType::IO;
-    } else if (res == "memory") {
-      resource_ = ResourceType::MEMORY;
-    }
-  } else {
-    OLOG << "Argument=resource missing or not (io|memory)";
-    return 1;
-  }
+  this->argParser_.addArgument("resource", resource_, true);
 
   return Base::init(args, context);
 }

--- a/src/oomd/plugins/PressureRisingBeyond.h
+++ b/src/oomd/plugins/PressureRisingBeyond.h
@@ -44,7 +44,7 @@ class PressureRisingBeyond : public Oomd::Engine::BasePlugin {
   // Initialized to bogus values; init() will crash oomd if non-0 return
   int threshold_;
   int duration_;
-  float fast_fall_ratio_;
+  float fast_fall_ratio_{0.85};
 
   ResourcePressure last_pressure_{100, 100, 100};
   std::chrono::steady_clock::time_point hit_thres_at_{};

--- a/src/oomd/plugins/SwapFree.cpp
+++ b/src/oomd/plugins/SwapFree.cpp
@@ -27,10 +27,9 @@ REGISTER_PLUGIN(swap_free, SwapFree::create);
 int SwapFree::init(
     const Engine::PluginArgs& args,
     const PluginConstructionContext& /* unused */) {
-  if (args.find("threshold_pct") != args.end()) {
-    threshold_pct_ = std::stoi(args.at("threshold_pct"));
-  } else {
-    OLOG << "Argument=threshold_pct not present";
+  argParser_.addArgument("threshold_pct", threshold_pct_, true);
+
+  if (!argParser_.parse(args)) {
     return 1;
   }
 

--- a/src/oomd/plugins/SwapFree.h
+++ b/src/oomd/plugins/SwapFree.h
@@ -39,7 +39,6 @@ class SwapFree : public Oomd::Engine::BasePlugin {
 
  private:
   int threshold_pct_; // will be assigned in init()
-  std::string swaps_location_;
 };
 
 } // namespace Oomd

--- a/src/oomd/util/PluginArgParser.cpp
+++ b/src/oomd/util/PluginArgParser.cpp
@@ -1,0 +1,138 @@
+#include <string>
+
+#include "oomd/include/Types.h"
+#include "oomd/util/PluginArgParser.h"
+
+namespace Oomd {
+
+std::unordered_set<CgroupPath> PluginArgParser::parseCgroup(
+    const PluginConstructionContext& context,
+    const std::string& cgroupStr) {
+  std::unordered_set<CgroupPath> res;
+  const auto& cgroup_fs = context.cgroupFs();
+  auto cgroups = Util::split(cgroupStr, ',');
+  for (const auto& c : cgroups) {
+    res.emplace(cgroup_fs, c);
+  }
+
+  return res;
+}
+
+int PluginArgParser::parseUnsignedInt(const std::string& intStr) {
+  int res = std::stoi(intStr);
+  if (res < 0) {
+    throw std::invalid_argument("must be non-negative");
+  }
+  return res;
+}
+
+void PluginArgParser::setName(const std::string& pluginName) {
+  pluginName_ = pluginName;
+}
+
+std::string PluginArgParser::getName() {
+  return pluginName_;
+}
+
+SystemMaybe<Unit> PluginArgParser::parse(const Engine::PluginArgs& args) {
+  for (const auto& argName : requiredArgs_) {
+    if (args.find(argName) == args.end()) {
+      OLOG << "Required arg \"" << argName << "\" missing in plugin \""
+           << pluginName_ << "\"";
+      return SYSTEM_ERROR(
+          EINVAL,
+          "Required arg \"",
+          argName,
+          "\" missing in plugin \"",
+          pluginName_,
+          "\"");
+    }
+  }
+  for (const auto& entry : args) {
+    if (argValueFillingFuncs_.find(entry.first) !=
+        argValueFillingFuncs_.end()) {
+      auto funcRes = argValueFillingFuncs_.at(entry.first)(entry.second);
+      if (!funcRes) {
+        return SYSTEM_ERROR(
+            EINVAL,
+            "Failed parsing arg for plugin \"",
+            pluginName_,
+            "\", error: ",
+            funcRes.error().what());
+      }
+    } else {
+      OLOG << "Unknown arg \"" << entry.first << "\" in plugin \""
+           << pluginName_ << "\"";
+      return SYSTEM_ERROR(
+          EINVAL,
+          "Unknown arg \"",
+          entry.first,
+          "\" in plugin \"",
+          pluginName_,
+          "\"");
+    }
+  }
+
+  return noSystemError();
+}
+
+std::unordered_set<std::string> PluginArgParser::validArgNames() {
+  std::unordered_set<std::string> res;
+  for (const auto& entry : argValueFillingFuncs_) {
+    res.emplace(entry.first);
+  }
+  return res;
+};
+
+template <>
+int64_t PluginArgParser::parseValue(const std::string& valueString) {
+  return std::stoull(valueString);
+}
+
+template <>
+int PluginArgParser::parseValue(const std::string& valueString) {
+  return std::stoi(valueString);
+}
+
+template <>
+double PluginArgParser::parseValue(const std::string& valueString) {
+  return std::stod(valueString);
+}
+
+template <>
+float PluginArgParser::parseValue(const std::string& valueString) {
+  return std::stof(valueString);
+}
+
+template <>
+bool PluginArgParser::parseValue(const std::string& valueString) {
+  if (valueString == "true" || valueString == "True" || valueString == "1") {
+    return true;
+  }
+
+  if (valueString == "false" || valueString == "False" || valueString == "0") {
+    return false;
+  }
+
+  throw std::invalid_argument(
+      "Invalid resource value, must be true/false, True/False, 1/0.");
+}
+
+template <>
+std::chrono::milliseconds PluginArgParser::parseValue(
+    const std::string& valueString) {
+  return std::chrono::milliseconds(std::stoll(valueString));
+}
+
+template <>
+ResourceType PluginArgParser::parseValue(const std::string& valueString) {
+  if (valueString == "io") {
+    return ResourceType::IO;
+  } else if (valueString == "memory") {
+    return ResourceType::MEMORY;
+  }
+  throw std::invalid_argument(
+      "Invalid resource value, must be either 'io' or 'memory'.");
+}
+
+} // namespace Oomd

--- a/src/oomd/util/PluginArgParser.h
+++ b/src/oomd/util/PluginArgParser.h
@@ -1,0 +1,95 @@
+#pragma once
+
+#include <string>
+#include <unordered_set>
+
+#include "oomd/Log.h"
+#include "oomd/PluginConstructionContext.h"
+#include "oomd/include/CgroupPath.h"
+#include "oomd/include/Types.h"
+#include "oomd/util/SystemMaybe.h"
+#include "oomd/util/Util.h"
+
+namespace Oomd {
+
+namespace {
+// this is to help deduce function template.
+// this is the same as std::type_identity in c++20
+template <typename T>
+struct Identity {
+  using type = T;
+};
+} // namespace
+
+class PluginArgParser {
+ public:
+  static std::unordered_set<CgroupPath> parseCgroup(
+      const PluginConstructionContext& context,
+      const std::string& cgroupStr);
+
+  static int parseUnsignedInt(const std::string& intStr);
+
+  PluginArgParser() {}
+  explicit PluginArgParser(const std::string& pluginName)
+      : pluginName_(pluginName) {}
+
+  void setName(const std::string& pluginName);
+  std::string getName();
+
+  // pasrse arg input, it fails (returns a error SystemMaybe) when:
+  // 1. any required arg is missing
+  // 2. any unknown arg passed in
+  // 3. failed to parse value string of any arg
+  SystemMaybe<Unit> parse(const Engine::PluginArgs& args);
+
+  // return a set of valid arg names registered
+  std::unordered_set<std::string> validArgNames();
+
+  template <typename T>
+  void
+  addArgument(const std::string& argName, T& argDest, bool required = false) {
+    addArgumentCustom(argName, argDest, parseValue<T>, required);
+  }
+
+  template <typename T>
+  void addArgumentCustom(
+      const std::string& argName,
+      T& argDest,
+      typename Identity<const std::function<T(const std::string&)>>::type& func,
+      bool required = false) {
+    if (required) {
+      requiredArgs_.emplace(argName);
+    }
+
+    argValueFillingFuncs_.emplace(
+        argName,
+        [&argDest, argName, func](
+            const std::string& valueStr) -> SystemMaybe<Unit> {
+          try {
+            argDest = func(valueStr);
+          } catch (std::exception& e) {
+            return SYSTEM_ERROR(
+                EINVAL,
+                "Failed to parse argument \"",
+                argName,
+                "\", error: ",
+                e.what());
+          }
+
+          return noSystemError();
+        });
+  }
+
+  template <typename T>
+  static T parseValue(const std::string& valueStr);
+
+ private:
+  std::unordered_map<
+      std::string,
+      std::function<SystemMaybe<Unit>(const std::string&)>>
+      argValueFillingFuncs_;
+  std::unordered_set<std::string> requiredArgs_;
+  std::string pluginName_;
+};
+
+} // namespace Oomd

--- a/src/oomd/util/PluginArgParserTest.cpp
+++ b/src/oomd/util/PluginArgParserTest.cpp
@@ -1,0 +1,269 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include "oomd/include/Types.h"
+#include "oomd/util/PluginArgParser.h"
+#include "oomd/util/Util.h"
+
+using namespace ::testing;
+
+namespace Oomd {
+
+TEST(ParseCGroup, testCgroupStringParsing) {
+  PluginConstructionContext context("/root/cgroupfs");
+  auto cgroups = PluginArgParser::parseCgroup(context, "cg1,cg2");
+  std::unordered_set<CgroupPath> expected{
+      {CgroupPath("/root/cgroupfs", "cg1")},
+      {CgroupPath("/root/cgroupfs", "cg2")}};
+
+  EXPECT_EQ(expected, cgroups);
+}
+
+TEST(ParseCGroup, testUnsignedIntParsing) {
+  auto res = PluginArgParser::parseUnsignedInt("123");
+  EXPECT_EQ(123, res);
+
+  EXPECT_THROW(
+      PluginArgParser::parseUnsignedInt("-123"), std::invalid_argument);
+}
+
+TEST(PluginArgParserTest, testPluginName) {
+  PluginArgParser p("test_plugin");
+  EXPECT_EQ("test_plugin", p.getName());
+
+  p.setName("new_plugin_name");
+  EXPECT_EQ("new_plugin_name", p.getName());
+}
+
+TEST(PluginArgParserTest, testArgParsingSuccess) {
+  int64_t valueLongInt;
+  int valueInt;
+  double valueDouble;
+  float valueFloat;
+  bool valueBool;
+  std::chrono::milliseconds valueMillis;
+  ResourceType valueResourceType;
+  std::vector<std::string> valueStrs;
+
+  PluginArgParser p("test_plugin");
+
+  std::function<std::vector<std::string>(const std::string&)> valueStrsFunc =
+      [](const std::string& valueStr) -> std::vector<std::string> {
+    return std::vector<std::string>{{valueStr + "-1", valueStr + "-2"}};
+  };
+  p.addArgument("arg_long_int", valueLongInt);
+  p.addArgument("arg_int", valueInt);
+  p.addArgument("arg_double", valueDouble);
+  p.addArgument("arg_float", valueFloat);
+  p.addArgument("arg_bool", valueBool);
+  p.addArgument("arg_milli_second", valueMillis);
+  p.addArgument("arg_resource_type", valueResourceType);
+  p.addArgumentCustom("arg_strs", valueStrs, valueStrsFunc);
+
+  // assert correct registered arg names
+  std::unordered_set<std::string> expectedArgNames{
+      {"arg_long_int"},
+      {"arg_int"},
+      {"arg_double"},
+      {"arg_float"},
+      {"arg_bool"},
+      {"arg_milli_second"},
+      {"arg_resource_type"},
+      {"arg_strs"}};
+  EXPECT_EQ(expectedArgNames, p.validArgNames());
+
+  Engine::PluginArgs inputArgs{
+      {"arg_long_int", "1234"},
+      {"arg_int", "4321"},
+      {"arg_double", "1.234"},
+      {"arg_float", "4.321"},
+      {"arg_bool", "true"},
+      {"arg_milli_second", "456"},
+      {"arg_resource_type", "io"},
+      {"arg_strs", "some_str"}};
+
+  auto res = p.parse(inputArgs);
+
+  EXPECT_TRUE(res);
+
+  EXPECT_EQ(1234, valueLongInt);
+  EXPECT_EQ(4321, valueInt);
+  EXPECT_EQ(1.234, valueDouble);
+  EXPECT_EQ(4.321f, valueFloat);
+  EXPECT_EQ(true, valueBool);
+  EXPECT_EQ(std::chrono::milliseconds(456), valueMillis);
+  EXPECT_EQ(ResourceType::IO, valueResourceType);
+
+  std::vector<std::string> expectedStrs{{"some_str-1"}, {"some_str-2"}};
+  EXPECT_EQ(expectedStrs, valueStrs);
+}
+
+TEST(PluginArgParserTest, testArgParsingSuccessOnResourceType) {
+  ResourceType valueResourceTypeIO;
+  ResourceType valueResourceTypeMem;
+
+  PluginArgParser p("test_plugin");
+
+  p.addArgument("arg_resource_type_io", valueResourceTypeIO);
+  p.addArgument("arg_resource_type_mem", valueResourceTypeMem);
+
+  // assert correct registered arg names
+  std::unordered_set<std::string> expectedArgNames{
+      {"arg_resource_type_io"}, {"arg_resource_type_mem"}};
+  EXPECT_EQ(expectedArgNames, p.validArgNames());
+
+  Engine::PluginArgs inputArgs{
+      {"arg_resource_type_io", "io"}, {"arg_resource_type_mem", "memory"}};
+
+  auto res = p.parse(inputArgs);
+
+  EXPECT_TRUE(res);
+
+  EXPECT_EQ(ResourceType::IO, valueResourceTypeIO);
+  EXPECT_EQ(ResourceType::MEMORY, valueResourceTypeMem);
+}
+
+TEST(PluginArgParserTest, testArgParsingFailedOnInvalidResourceType) {
+  ResourceType valueResourceType;
+
+  PluginArgParser p("test_plugin");
+
+  p.addArgument("arg_resource_type_io", valueResourceType);
+
+  Engine::PluginArgs inputArgs{{"arg_resource_type_io", "kidding"}};
+
+  auto res = p.parse(inputArgs);
+
+  EXPECT_FALSE(res);
+  EXPECT_THAT(
+      std::string(res.error().what()),
+      HasSubstr("Failed to parse argument \"arg_resource_type_io\", error"));
+}
+
+TEST(PluginArgParserTest, testArgParsingSuccessOnBool) {
+  bool value1 = false;
+  bool value2 = false;
+  bool value3 = false;
+  bool value4 = true;
+  bool value5 = true;
+  bool value6 = true;
+
+  PluginArgParser p("test_plugin");
+
+  p.addArgument("arg_1", value1);
+  p.addArgument("arg_2", value2);
+  p.addArgument("arg_3", value3);
+  p.addArgument("arg_4", value4);
+  p.addArgument("arg_5", value5);
+  p.addArgument("arg_6", value6);
+
+  Engine::PluginArgs inputArgs{
+      {"arg_1", "true"},
+      {"arg_2", "True"},
+      {"arg_3", "1"},
+      {"arg_4", "false"},
+      {"arg_5", "False"},
+      {"arg_6", "0"}};
+
+  auto res = p.parse(inputArgs);
+
+  EXPECT_TRUE(res);
+
+  EXPECT_EQ(true, value1);
+  EXPECT_EQ(true, value2);
+  EXPECT_EQ(true, value3);
+  EXPECT_EQ(false, value4);
+  EXPECT_EQ(false, value5);
+  EXPECT_EQ(false, value6);
+}
+
+TEST(PluginArgParserTest, testArgParsingFailedOnInvalidBool) {
+  bool valueResourceType;
+
+  PluginArgParser p("test_plugin");
+
+  p.addArgument("arg_bool", valueResourceType);
+
+  Engine::PluginArgs inputArgs{{"arg_bool", "kidding"}};
+
+  auto res = p.parse(inputArgs);
+
+  EXPECT_FALSE(res);
+  EXPECT_THAT(
+      std::string(res.error().what()),
+      HasSubstr("Failed to parse argument \"arg_bool\", error"));
+}
+
+TEST(PluginArgParserTest, testArgParsingFailedWithUnkownArg) {
+  int64_t valueLongInt;
+
+  PluginArgParser p("test_plugin");
+
+  p.addArgument("arg", valueLongInt);
+
+  // assert correct registered arg names
+  std::unordered_set<std::string> expectedArgNames{{"arg"}};
+  EXPECT_EQ(expectedArgNames, p.validArgNames());
+
+  Engine::PluginArgs inputArgs{{"arg", "1234"}, {"unknown_arg", "4321"}};
+
+  auto res = p.parse(inputArgs);
+
+  EXPECT_FALSE(res);
+  EXPECT_THAT(
+      std::string(res.error().what()),
+      HasSubstr(
+          "Unknown arg \"unknown_arg\" in plugin \"test_plugin\": Invalid argument"));
+}
+
+TEST(PluginArgParserTest, testArgParsingFailedWithMissingRequired) {
+  int64_t valueLongInt;
+  int64_t anotherLongInt;
+
+  PluginArgParser p("test_plugin");
+
+  p.addArgument("arg1", valueLongInt);
+  p.addArgument("arg2", anotherLongInt, true);
+
+  // assert correct registered arg names
+  std::unordered_set<std::string> expectedArgNames{{"arg1"}, {"arg2"}};
+  EXPECT_EQ(expectedArgNames, p.validArgNames());
+
+  Engine::PluginArgs inputArgs{{"arg1", "1234"}};
+
+  auto res = p.parse(inputArgs);
+
+  EXPECT_FALSE(res);
+  EXPECT_THAT(
+      std::string(res.error().what()),
+      HasSubstr(
+          "Required arg \"arg2\" missing in plugin \"test_plugin\": Invalid argument"));
+}
+
+TEST(PluginArgParserTest, testArgParsingFailedWithInvalidValueStr) {
+  int64_t valueLongInt;
+
+  PluginArgParser p("test_plugin");
+
+  p.addArgument("bad_arg", valueLongInt);
+
+  // assert correct registered arg names
+  std::unordered_set<std::string> expectedArgNames{{"bad_arg"}};
+  EXPECT_EQ(expectedArgNames, p.validArgNames());
+
+  Engine::PluginArgs inputArgs{{"bad_arg", "abcdefg"}};
+
+  auto res = p.parse(inputArgs);
+
+  EXPECT_FALSE(res);
+  EXPECT_THAT(
+      std::string(res.error().what()),
+      HasSubstr("Failed to parse argument \"bad_arg\", error"));
+}
+
+} // namespace Oomd


### PR DESCRIPTION
Summary: Creating a arg parsing util for oomd plugins with unknown args logging and default value parsing for some primitive value types.

Reviewed By: lnyng

Differential Revision: D26579329

