### PR TITLE
fix variable name in REGISTER_PREKILL_HOOK macro

### DIFF
--- a/src/oomd/PluginRegistry.h
+++ b/src/oomd/PluginRegistry.h
@@ -70,7 +70,7 @@ PluginRegistry<Engine::BasePlugin>& getPluginRegistry();
 PluginRegistry<Engine::PrekillHook>& getPrekillHookRegistry();
 
 #define REGISTER_PREKILL_HOOK(hook_name, create_func) \
-  bool plugin_name##_plugin_entry =                   \
+  bool hook_name##_plugin_entry =                     \
       getPrekillHookRegistry().add(#hook_name, (create_func))
 
 } // namespace Oomd


### PR DESCRIPTION
Summary: this does not block anything...but just make ci fails in github. complaining redefinition of `plugin_name_plugin_entry`. For example D27460353

Differential Revision: D27476943

