### PR TITLE
Fix CI apt-get

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,7 @@ jobs:
       CC: ${{ matrix.cc }}
       CXX: ${{ matrix.cxx }}
     steps:
+      - run: sudo apt-get update
       - name: Install dependencies
         run: >
           sudo apt-get install


### PR DESCRIPTION
Summary: Fix CI by invoking apt-get update before fetching.

Differential Revision: D29312189

