### PR TITLE
configuration.md: space-fixes

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -62,12 +62,12 @@ oomd configs have a loosely defined BNF:
 
     ROOT:
     {
-        "rulesets": [ RULESET[,RULESET[,...]]  ],
+        "rulesets": [ RULESET[,RULESET[,...]] ],
         "prekill_hooks": [ PLUGIN ]
     }
 
 In plain english, the general idea is that each oomd config one or more
-RULESETs.  Each RULESET has a set of DETECTOR_GROUPs and a set of ACTIONs. Each
+RULESETs. Each RULESET has a set of DETECTOR_GROUPs and a set of ACTIONs. Each
 DETECTOR_GROUP has a set of DETECTORs. Both DETECTORs and ACTIONs are PLUGIN
 types. That means _everything_ is a plugin in oomd. The rules on how a
 conforming config is evaluated at runtime are described in the next section.


### PR DESCRIPTION
Removed one space at the end of list. Example above uses also just one space.  
Removed double-space inbetween sentences. If the original intention was to create a new paragraph, then revert this one.