### PR TITLE
Resolved a compiler error due to lacking include

### DIFF
--- a/src/oomd/Log.h
+++ b/src/oomd/Log.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include <algorithm>
+#include <array>
 #include <condition_variable>
 #include <iostream>
 #include <mutex>
@@ -139,10 +140,10 @@ class LogStream {
 // Must declare explicit specialization in *namespace* scope (class scope
 // doesn't count) for some weird reason according to the C++ spec.
 template <>
-LogStream& LogStream::operator<<<LogStream::Control>(const Control& ctrl);
+LogStream& LogStream::operator<< <LogStream::Control>(const Control& ctrl);
 
 template <>
-LogStream& LogStream::operator<<<LogStream::Offset>(const Offset& offset);
+LogStream& LogStream::operator<< <LogStream::Offset>(const Offset& offset);
 
 template <typename... Args>
 static void OOMD_KMSG_LOG(Args&&... args) {


### PR DESCRIPTION
Fixed an issue where a missing include causing compiler errors

Also applied clang-format.sh

Issue occured with following compiler and linker:
```
C++ compiler for the host machine: ccache c++ (gcc 12.1.1 "c++ (GCC) 12.1.1 20220507 (Red Hat 12.1.1-1)")
C++ linker for the host machine: c++ ld.bfd 2.37-27
```