### PR TITLE
Fix directory classification in readDir fallback

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -175,6 +175,7 @@ if gtest_dep.found() and gmock_dep.found()
             include_directories : inc,
             cpp_args : cpp_args,
             dependencies : deps,
+            link_args : test_name == 'util' ? ['-Wl,--wrap=readdir64'] : [],
             link_whole : [oomd_lib, oomd_fixture_lib])
         test(executable_name_suffix,
              test_executable,

--- a/src/oomd/util/Fs.cpp
+++ b/src/oomd/util/Fs.cpp
@@ -152,7 +152,7 @@ SystemMaybe<Fs::DirEnts> Fs::readDirFromDIR(DIR* d, int flags) {
       de.files.emplace_back(dir->d_name);
     }
     if ((flags & DirEntFlags::DE_DIR) && (buf.st_mode & S_IFDIR)) {
-      de.files.emplace_back(dir->d_name);
+      de.dirs.emplace_back(dir->d_name);
     }
   }
 

--- a/src/oomd/util/FsTest.cpp
+++ b/src/oomd/util/FsTest.cpp
@@ -29,6 +29,16 @@
 using namespace Oomd;
 using namespace testing;
 
+extern "C" struct dirent* __real_readdir64(DIR* dir);
+
+extern "C" struct dirent* __wrap_readdir64(DIR* dir) {
+  auto* entry = __real_readdir64(dir);
+  if (entry) {
+    entry->d_type = DT_UNKNOWN;
+  }
+  return entry;
+}
+
 class FsTest : public ::testing::Test {
  protected:
   void SetUp() override {
@@ -50,7 +60,7 @@ class FsTest : public ::testing::Test {
   FsFixture fixture_{};
 };
 
-TEST_F(FsTest, FindDirectories) {
+TEST_F(FsTest, FindDirsFallback) {
   auto dir = fixture_.fsDataDir();
   auto de = ASSERT_SYS_OK(Fs::readDir(dir, Fs::DE_DIR));
 


### PR DESCRIPTION
Fix directories discovered through the `fstatat()` fallback being appended to
the files result instead of the directories result.

The util test wraps `readdir64()` so directory entries report `DT_UNKNOWN`,
ensuring its directory assertions exercise the fallback rather than the
`d_type` fast path.

Tested with the full Meson suite under GCC, Clang, and Clang with AddressSanitizer
(12/12 test suites passed in each configuration).

Fixes #177.
